### PR TITLE
Fix assertion: IgnoreValue don't work

### DIFF
--- a/src/Rooibos_BaseTestSuite.brs
+++ b/src/Rooibos_BaseTestSuite.brs
@@ -1513,20 +1513,17 @@ end function
 '  * @returns {Object} - stub that was wired into the real method
 '  */
 function RBS_BTS_CreateFake(id, target, methodName, expectedInvocations = 1, expectedArgs =invalid, returnValue=invalid ) as object
+  defaultValue = invalid
   expectedArgsValues = []
-  hasArgs = expectedArgs <> invalid
-  if (hasArgs)
-    defaultValue = m.invalidValue
-  else
-    defaultValue = m.ignoreValue
-  end if
+
+  hasArgs = expectedArgs <> invalid and expectedArgs.count() > 0
+  if not hasArgs then defaultValue = m.ignoreValue
 
   for i = 0 to 9
-    if (hasArgs and expectedArgs.count() > i)
-      expectedArgsValues.push(expectedArgs[i])
-    else
-      expectedArgsValues.push(defaultValue)
-    end if
+    value = defaultValue
+
+    if (hasArgs and expectedArgs[i] <> invalid) then value = expectedArgs[i]
+    expectedArgsValues.push(value)
   end for
   fake = {
     id : id,

--- a/src/Rooibos_BaseTestSuite.brs
+++ b/src/Rooibos_BaseTestSuite.brs
@@ -11,12 +11,12 @@ function BaseTestSuite() as Object
   this.invalidValue = "#ROIBOS#INVALID_VALUE" ' special value used in mock arguments
   this.ignoreValue = "#ROIBOS#IGNORE_VALUE" ' special value used in mock arguments
   this.isAutoAssertingMocks = true
-  
+
   'Test Cases methods
   this.TestCases = []
   this.AddTest            = RBS_BTS_AddTest
   this.CreateTest           = RBS_BTS_CreateTest
-  
+
   'Assertion methods which determine test failure
   this.GetLegacyCompatibleReturnValue = RBS_BTS_GetLegacyCompatibleReturnValue
   this.Fail               = RBS_BTS_Fail
@@ -43,7 +43,7 @@ function BaseTestSuite() as Object
   this.AssertArrayContainsOnlyValuesOfType    = RBS_BTS_AssertArrayContainsOnlyValuesOfType
   this.AssertType           = RBS_BTS_AssertType
   this.AssertSubType        = RBS_BTS_AssertSubType
-  
+
   'Node extensions
   this.AssertNodeCount         = RBS_BTS_AssertNodeCount
   this.AssertNodeNotCount      = RBS_BTS_AssertNodeNotCount
@@ -62,7 +62,7 @@ function BaseTestSuite() as Object
   this.EqArray             = RBS_BTS_EqArray
 
   'Mocking and stubbing
-  
+
   this.Stub       = RBS_BTS_Stub
   this.Mock       = RBS_BTS_Mock
   this.AssertMocks    = RBS_BTS_AssertMocks
@@ -70,18 +70,18 @@ function BaseTestSuite() as Object
   this.MockFail     = RBS_BTS_MockFail
   this.CleanMocks     = RBS_BTS_CleanMocks
   this.CleanStubs     = RBS_BTS_CleanStubs
-  
+
   'Mocking short hand methods
   this.ExpectOnce     = RBS_BTS_ExpectOnce
   this.ExpectNone     = RBS_BTS_ExpectNone
   this.Expect     = RBS_BTS_Expect
-  
-  
+
+
   'note the following callbacks are mapped as we don't have reflection in brightscript
   'and we need context to know what fields are called
   'I avoided using eval, as I don't know what threads tests might run in
   'so dont' want to risk srewing with people's lives
-  
+
   'Callback mapping - mocks
   this.MockCallback0     = RBS_BTS_MockCallback0
   this.MockCallback1     = RBS_BTS_MockCallback1
@@ -89,8 +89,8 @@ function BaseTestSuite() as Object
   this.MockCallback3     = RBS_BTS_MockCallback3
   this.MockCallback4     = RBS_BTS_MockCallback4
   this.MockCallback5     = RBS_BTS_MockCallback5
-  
-  
+
+
   'Callback mapping - Stubs
   this.StubCallback0     = RBS_BTS_StubCallback0
   this.StubCallback1     = RBS_BTS_StubCallback1
@@ -98,7 +98,7 @@ function BaseTestSuite() as Object
   this.StubCallback3     = RBS_BTS_StubCallback3
   this.StubCallback4     = RBS_BTS_StubCallback4
   this.StubCallback5     = RBS_BTS_StubCallback5
-  
+
   'utility functions to make life nicer
   this.pathAsArray_ = RBS_BTS_rodash_pathsAsArray_
   this.g = RBS_BTS_rodash_get_
@@ -113,7 +113,7 @@ End Function
 '  * @description Add a test to a suite's test cases array. Used internally.
 '  * @param {Dynamic} name - A test name.
 '  * @param {Dynamic} func - A test function name.
-'  */ 
+'  */
 Sub RBS_BTS_AddTest(name as String, func as Object, funcName as String, setup = invalid as Object, teardown = invalid as Object)
   m.testCases.Push(m.createTest(name, func, funcName, setup, teardown))
 End Sub
@@ -126,14 +126,14 @@ End Sub
 '  * @description Create a test object. Used internally
 '  * @param {Dynamic} name - A test name.
 '  * @param {Dynamic} func - A test function name.
-'  */ 
+'  */
 Function RBS_BTS_CreateTest(name as String, func as Object, funcName as String, setup = invalid as Object, teardown = invalid as Object) as Object
 
-  if (func = invalid) 
+  if (func = invalid)
 '    ? " ASKED TO CREATE TEST WITH INVALID FUNCITON POINTER FOR FUNCTION " ; funcName
 '    ? " Looking it up now"
     res = eval("functionPointer=" + funcName)
-    
+
     if (RBS_CMN_IsInteger(res) and res = 252 and functionPointer <> invalid)
 '      ? "found the function"
       func = functionPointer
@@ -142,7 +142,7 @@ Function RBS_BTS_CreateTest(name as String, func as Object, funcName as String, 
     end if
   end if
   return {
-    Name: name 
+    Name: name
     Func: func
     FuncName: funcName
     SetUp: setup
@@ -176,13 +176,13 @@ Function RBS_BTS_GetLegacyCompatibleReturnValue(value) as Object
   else
     return true
   end if
-  else  
+  else
   if (m.isLegacy = true)
     return "ERROR"
   else
     return false
   end if
-  end if 
+  end if
 End Function
 
 ' /**
@@ -194,10 +194,10 @@ End Function
 '  * @param {Dynamic} expr - An expression to evaluate.
 '  * @param {Dynamic} [msg=""] - alternate error message
 ' Default value: "Expression evaluates to true"'  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertFalse(expr as dynamic, msg = "Expression evaluates to true" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if not RBS_CMN_IsBoolean(expr) or expr 
+  if not RBS_CMN_IsBoolean(expr) or expr
     m.currentResult.AddResult(msg)
     return m.fail(msg)
   end if
@@ -214,7 +214,7 @@ End Function
 '  * @param {Dynamic} expr - An expression to evaluate.
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertTrue(expr as dynamic, msg = "Expression evaluates to false" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if not RBS_CMN_IsBoolean(expr) or not expr then
@@ -235,14 +235,14 @@ End Function
 '  * @param {Dynamic} second - second object to compare
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertEqual(first as dynamic, second as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if not m.eqValues(first, second)
     if msg = ""
       first_as_string = RBS_CMN_AsString(first)
       second_as_string = RBS_CMN_AsString(second)
-      msg = first_as_string + " != " + second_as_string 
+      msg = first_as_string + " != " + second_as_string
     end if
     m.currentResult.AddResult(msg)
     return m.GetLegacyCompatibleReturnValue(false)
@@ -261,14 +261,14 @@ End Function
 '  * @param {Dynamic} second - second object to compare
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertLike(first as dynamic, second as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if first <> second
     if msg = ""
       first_as_string = RBS_CMN_AsString(first)
       second_as_string = RBS_CMN_AsString(second)
-      msg = first_as_string + " != " + second_as_string 
+      msg = first_as_string + " != " + second_as_string
     end if
     m.currentResult.AddResult(msg)
     return m.GetLegacyCompatibleReturnValue(false)
@@ -287,14 +287,14 @@ End Function
 '  * @param {Dynamic} second - second object to compare
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNotEqual(first as dynamic, second as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if m.eqValues(first, second)
     if msg = ""
       first_as_string = RBS_CMN_AsString(first)
       second_as_string = RBS_CMN_AsString(second)
-      msg = first_as_string + " == " + second_as_string 
+      msg = first_as_string + " == " + second_as_string
     end if
     m.currentResult.AddResult(msg)
     return m.GetLegacyCompatibleReturnValue(false)
@@ -312,7 +312,7 @@ End Function
 '  * @param {Dynamic} value - value to check - value to check for
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertInvalid(value as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if value <> Invalid
@@ -336,7 +336,7 @@ End Function
 '  * @param {Dynamic} value - value to check - value to check for
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNotInvalid(value as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if value = Invalid
@@ -361,7 +361,7 @@ End Function
 '  * @param {Dynamic} key - key name
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertAAHasKey(array as dynamic, key as string, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array)
@@ -391,7 +391,7 @@ End Function
 '  * @param {Dynamic} key - key name
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertAANotHasKey(array as dynamic, key as string, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array)
@@ -421,7 +421,7 @@ End Function
 '  * @param {Dynamic} keys - Array of key names.
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertAAHasKeys(array as dynamic, keys as object, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array) and RBS_CMN_IsArray(keys)
@@ -453,7 +453,7 @@ End Function
 '  * @param {Dynamic} keys - Array of key names.
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertAANotHasKeys(array as dynamic, keys as object, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array) and RBS_CMN_IsArray(keys)
@@ -488,7 +488,7 @@ End Function
 '  * @param {Dynamic} key - key name in associative array
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayContains(array as dynamic, value as dynamic, key = invalid as string, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array) or RBS_CMN_IsArray(array)
@@ -516,16 +516,16 @@ End Function
 '  * @param {Dynamic} values - array of aas to look for in target array
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayContainsAAs(array as dynamic, values as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  
+
   if not RBS_CMN_IsArray(values)
     msg = "values to search for are not an Array."
     m.currentResult.AddResult(msg)
     return m.GetLegacyCompatibleReturnValue(false)
   end if
-  
+
   if RBS_CMN_IsArray(array)
     for each value in values
     isMatched = false
@@ -551,13 +551,13 @@ Function RBS_BTS_AssertArrayContainsAAs(array as dynamic, values as dynamic, msg
       end if
       end if
     end for ' items in array
-      
+
     if not isMatched
       msg = "array missing value: "+  RBS_CMN_AsString(value)
       m.currentResult.AddResult(msg)
       return m.GetLegacyCompatibleReturnValue(false)
     end if
-  
+
     end for 'values to match
   else
     msg = "Input value is not an Array."
@@ -580,7 +580,7 @@ End Function
 '  * @param {Dynamic} key - A key name for associative array.
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayNotContains(array as dynamic, value as dynamic, key = invalid as string, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array) or RBS_CMN_IsArray(array)
@@ -608,7 +608,7 @@ End Function
 '  * @param {Dynamic} subset - items to check presnece of
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayContainsSubset(array as dynamic, subset as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if (RBS_CMN_IsAssociativeArray(array) and RBS_CMN_IsAssociativeArray(subset)) or (RBS_CMN_IsArray(array) and RBS_CMN_IsArray(subset))
@@ -645,7 +645,7 @@ End Function
 '  * @param {Dynamic} subset - items to check presnece of
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayNotContainsSubset(array as dynamic, subset as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if (RBS_CMN_IsAssociativeArray(array) and RBS_CMN_IsAssociativeArray(subset)) or (RBS_CMN_IsArray(array) and RBS_CMN_IsArray(subset))
@@ -682,7 +682,7 @@ End Function
 '  * @param {Dynamic} count - An expected array items count
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayCount(array as dynamic, count as integer, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array) or RBS_CMN_IsArray(array)
@@ -710,7 +710,7 @@ End Function
 '  * @param {Dynamic} count - An expected array items count.
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayNotCount(array as dynamic, count as integer, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(array) or RBS_CMN_IsArray(array)
@@ -737,7 +737,7 @@ End Function
 '  * @param {Dynamic} item - item to check
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertEmpty(item as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(item) or RBS_CMN_IsArray(item)
@@ -752,7 +752,7 @@ Function RBS_BTS_AssertEmpty(item as dynamic, msg = "" as string) as dynamic
       m.currentResult.AddResult(msg)
       return m.GetLegacyCompatibleReturnValue(false)
     end if
-  else 
+  else
     msg = "AssertEmpty: Input value was not an array or a string"
     m.currentResult.AddResult(msg)
     return m.GetLegacyCompatibleReturnValue(false)
@@ -770,7 +770,7 @@ End Function
 '  * @param {Dynamic} item - item to check
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNotEmpty(item as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if RBS_CMN_IsAssociativeArray(item) or RBS_CMN_IsArray(item)
@@ -804,15 +804,15 @@ End Function
 '  * @param {Dynamic} typeStr - type name - must be String, Array, Boolean, or AssociativeArray
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertArrayContainsOnlyValuesOfType(array as dynamic, typeStr as string, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if typeStr <> "String" and typeStr <> "Integer" and typeStr <> "Boolean" and typeStr <> "Array" and typeStr <> "AssociativeArray"
     msg = "Type must be Boolean, String, Array, Integer, or AssociativeArray"
     m.currentResult.AddResult(msg)
-    return m.GetLegacyCompatibleReturnValue(false) 
+    return m.GetLegacyCompatibleReturnValue(false)
   end if
-  
+
   if RBS_CMN_IsAssociativeArray(array) or RBS_CMN_IsArray(array)
     methodName = "RBS_CMN_Is" + typeStr
     typeCheckFunction = RBS_CMN_GetFunction(invalid, methodName)
@@ -822,12 +822,12 @@ Function RBS_BTS_AssertArrayContainsOnlyValuesOfType(array as dynamic, typeStr a
           msg = RBS_CMN_AsString(item) + "is not a '" + typeStr + "' type."
           m.currentResult.AddResult(msg)
           return m.GetLegacyCompatibleReturnValue(false)
-        end if  
+        end if
       end for
     else
       msg = "could not find comparator for type '" + typeStr + "' type."
       m.currentResult.AddResult(msg)
-      return m.GetLegacyCompatibleReturnValue(false)  
+      return m.GetLegacyCompatibleReturnValue(false)
     end if
   else
     msg = "Input value is not an Array."
@@ -848,7 +848,7 @@ End Function
 '  * @param {Dynamic} typeStr - type name
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 function RBS_BTS_AssertType(value as dynamic, typeStr as string, msg ="" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if type(value) <> typeStr
@@ -873,7 +873,7 @@ end function
 '  * @param {Dynamic} typeStr - type name
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 function RBS_BTS_AssertSubType(value as dynamic, typeStr as string, msg ="" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if type(value) <> "roSGNode"
@@ -904,7 +904,7 @@ end function
 '  * @param {Dynamic} Vallue1 - first item to compare
 '  * @param {Dynamic} Vallue2 - second item to compare
 '  * @returns {boolean} - True if values are equal or False in other case.
-'  */ 
+'  */
 Function RBS_BTS_EqValues(Value1 as dynamic, Value2 as dynamic) as dynamic
   ' Workaraund for bug with string boxing, and box everything else
   val1Type = type(Value1)
@@ -912,14 +912,14 @@ Function RBS_BTS_EqValues(Value1 as dynamic, Value2 as dynamic) as dynamic
   if val1Type = "<uninitialized>" or val2Type = "<uninitialized>"
     ? "ERROR!!!! - undefined value passed"
     return false
-  end if 
-  
+  end if
+
   if val1Type = "roString" or val1Type = "String"
     Value1 = RBS_CMN_AsString(Value1)
   else
     Value1 = box(Value1)
   end if
-  
+
   if val2Type = "roString" or val2Type = "String"
     Value2 = RBS_CMN_AsString(Value2)
   else
@@ -929,7 +929,7 @@ Function RBS_BTS_EqValues(Value1 as dynamic, Value2 as dynamic) as dynamic
   val1Type = type(Value1)
   val2Type = type(Value2)
 
-  
+
   'Upcast int to float, if other is float
   if val1Type = "roFloat" and val2Type = "roInt"
     Value2 = box(Cdbl(Value2))
@@ -941,7 +941,7 @@ Function RBS_BTS_EqValues(Value1 as dynamic, Value2 as dynamic) as dynamic
     return false
   else
     valtype = val1Type
-    
+
     if valtype = "<uninitialized>"
       return false
     else if valtype = "roList"
@@ -961,9 +961,9 @@ Function RBS_BTS_EqValues(Value1 as dynamic, Value2 as dynamic) as dynamic
       '2 things which can't be compared - check what value1 and value2
       'are in your debug log
       return Value1 = Value2
-    end if  
+    end if
   end if
-End Function 
+End Function
 
 ' /**
 '  * @memberof module:BaseTestSuite
@@ -974,11 +974,11 @@ End Function
 '  * @param {Dynamic} Vallue1 - first associative array
 '  * @param {Dynamic} Vallue2 - second associative array
 '  * @returns {boolean} - True if arrays are equal or False in other case.
-'  */ 
+'  */
 Function RBS_BTS_EqAssocArray(Value1 as Object, Value2 as Object) as dynamic
   l1 = Value1.Count()
   l2 = Value2.Count()
-  
+
   if not l1 = l2
     return false
   else
@@ -995,7 +995,7 @@ Function RBS_BTS_EqAssocArray(Value1 as Object, Value2 as Object) as dynamic
     end for
     return true
   end if
-End Function 
+End Function
 
 ' /**
 '  * @memberof module:BaseTestSuite
@@ -1006,13 +1006,13 @@ End Function
 '  * @param {Dynamic} Vallue1 - first array
 '  * @param {Dynamic} Vallue2 - second array
 '  * @returns {boolean} - True if arrays are equal or False in other case.
-'  */ 
+'  */
 Function RBS_BTS_EqArray(Value1 as Object, Value2 as Object) as dynamic
   if not (RBS_CMN_IsArray(Value1)) or not RBS_CMN_IsArray(Value2) then return false
-  
+
   l1 = Value1.Count()
   l2 = Value2.Count()
-  
+
   if not l1 = l2
     return false
   else
@@ -1044,10 +1044,10 @@ End Function
 '  * @param {Dynamic} count - expected number of child items
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeCount(node as dynamic, count as integer, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if type(node) = "roSGNode" 
+  if type(node) = "roSGNode"
     if node.getChildCount() <> count
       msg = "node items count <> " + RBS_CMN_AsString(count) + ". Received " + RBS_CMN_AsString(node.getChildCount())
       m.currentResult.AddResult(msg)
@@ -1072,10 +1072,10 @@ End Function
 '  * @param {Dynamic} count - Expected item count
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeNotCount(node as dynamic, count as integer, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if type(node) = "roSGNode" 
+  if type(node) = "roSGNode"
     if node.getChildCount() = count
       msg = "node items count = " + RBS_CMN_AsString(count) + "."
       m.currentResult.AddResult(msg)
@@ -1099,10 +1099,10 @@ End Function
 '  * @param {Dynamic} node - a node to check
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeEmpty(node as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if type(node) = "roSGNode" 
+  if type(node) = "roSGNode"
     if node.getChildCount() > 0
       msg = "node is not empty."
       m.currentResult.AddResult(msg)
@@ -1122,10 +1122,10 @@ End Function
 '  * @param {Dynamic} node - a node to check
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeNotEmpty(node as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if type(node) = "roSGNode" 
+  if type(node) = "roSGNode"
     if node.Count() = 0
       msg = "Array is empty."
       m.currentResult.AddResult(msg)
@@ -1146,10 +1146,10 @@ End Function
 '  * @param {Dynamic} value - value to check - value to look for
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeContains(node as dynamic, value as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if  type(node) = "roSGNode" 
+  if  type(node) = "roSGNode"
     if not RBS_CMN_NodeContains(node, value)
       msg = "Node doesn't have the '" + RBS_CMN_AsString(value) + "' value."
       m.currentResult.AddResult(msg)
@@ -1174,10 +1174,10 @@ End Function
 '  * @param {Dynamic} value - value to check - value to look for
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeContainsOnly(node as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if  type(node) = "roSGNode" 
+  if  type(node) = "roSGNode"
     if not RBS_CMN_NodeContains(node, value)
       msg = "Node doesn't have the '" + RBS_CMN_AsString(value) + "' value."
       m.currentResult.AddResult(msg)
@@ -1207,10 +1207,10 @@ End Function
 '  * @param {Dynamic} value - value to check - a node child
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeNotContains(node as dynamic, value as dynamic, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if  type(node) = "roSGNode" 
+  if  type(node) = "roSGNode"
     if RBS_CMN_NodeContains(node, value)
       msg = "Node has the '" + RBS_CMN_AsString(value) + "' value."
       m.currentResult.AddResult(msg)
@@ -1235,7 +1235,7 @@ End Function
 '  * @param {Dynamic} subset - items to check
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertNodeContainsFields(node as dynamic, subset as dynamic, ignoredFields=invalid, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
   if ( type(node) = "roSGNode" and RBS_CMN_IsAssociativeArray(subset)) or ( type(node) = "roSGNode"  and RBS_CMN_IsArray(subset))
@@ -1253,7 +1253,7 @@ Function RBS_BTS_AssertNodeContainsFields(node as dynamic, subset as dynamic, ig
           end if
         end if
       else
-        ? "Found empty key!"  
+        ? "Found empty key!"
       end if
     end for
   else
@@ -1317,10 +1317,10 @@ End Function
 '  * @param {Dynamic} ignoredFields - array of fieldnames to ignore while comparing
 '  * @param {Dynamic} [msg=""] - alternate error message
 '  * @returns {boolean} - true if the assert was satisfied, false otherwise
-'  */ 
+'  */
 Function RBS_BTS_AssertAAContainsSubset(array as dynamic, subset as dynamic, ignoredFields = invalid, msg = "" as string) as dynamic
   if (m.currentResult.isFail) then return m.GetLegacyCompatibleReturnValue(false) ' skip test we already failed
-  if (RBS_CMN_IsAssociativeArray(array) and RBS_CMN_IsAssociativeArray(subset)) 
+  if (RBS_CMN_IsAssociativeArray(array) and RBS_CMN_IsAssociativeArray(subset))
     isAA = RBS_CMN_IsAssociativeArray(subset)
     isIgnoredFields = RBS_CMN_IsArray(ignoredFields)
     for each key in subset
@@ -1335,12 +1335,12 @@ Function RBS_BTS_AssertAAContainsSubset(array as dynamic, subset as dynamic, ign
           end if
         end if
       else
-        ? "Found empty key!"  
+        ? "Found empty key!"
       end if
     end for
   else
     msg = "Input values are not an Associative Array."
-    
+
     return m.GetLegacyCompatibleReturnValue(false)
   end if
   m.currentResult.AddResult("")
@@ -1364,7 +1364,7 @@ End Function
 '  * @param {Dynamic} [returnValue=invalid] - value that the stub method will return when invoked
 '  * @param {boolean} [allowNonExistingMethods=false] - if true, then rooibos will only warn if the method did not exist prior to faking
 '  * @returns {Object} - stub that was wired into the real method
-'  */ 
+'  */
 function RBS_BTS_Stub(target, methodName, returnValue = invalid, allowNonExistingMethods = false) as object
   if (type(target) <> "roAssociativeArray")
     m.Fail("could not create Stub provided target was null")
@@ -1376,12 +1376,12 @@ function RBS_BTS_Stub(target, methodName, returnValue = invalid, allowNonExistin
     m.stubs = {}
   end if
   m.__stubId++
-    
+
   if (m.__stubId > 5)
      ? "ERROR ONLY 6 STUBS PER TEST ARE SUPPORTED!!"
      return invalid
   end if
-  
+
   id = stri(m.__stubId).trim()
 
   fake = m.CreateFake(id, target, methodName, 1, invalid, returnValue)
@@ -1389,14 +1389,14 @@ function RBS_BTS_Stub(target, methodName, returnValue = invalid, allowNonExistin
   if (type(target[methodName]) = "Function" or type(target[methodName]) = "roFunction" or allowNonExistingMethods)
     target[methodName] = m["StubCallback" + id]
     target.__stubs = m.stubs
-    
+
     if (allowNonExistingMethods)
       ? "WARNING - stubbing call " ; methodName; " which did not exist on target object"
     end if
   else
-    ? "ERROR - could not create Stub : method not found  "; target ; "." ; methodName 
+    ? "ERROR - could not create Stub : method not found  "; target ; "." ; methodName
   end if
-  
+
   return fake
 end function
 
@@ -1412,10 +1412,10 @@ end function
 '  * @param {Dynamic} [returnValue=invalid] - value that the stub method will return when invoked
 '  * @param {boolean} [allowNonExistingMethods=false] - if true, then rooibos will only warn if the method did not exist prior to faking
 '  * @returns {Object} - mock that was wired into the real method
-'  */ 
+'  */
 function RBS_BTS_ExpectOnce(target, methodName, expectedArgs = invalid, returnValue = invalid, allowNonExistingMethods = false) as object
   return m.Mock(target, methodName, 1, expectedArgs, returnValue, allowNonExistingMethods)
-end function 
+end function
 
 ' /**
 '  * @memberof module:BaseTestSuite
@@ -1427,10 +1427,10 @@ end function
 '  * @param {Dynamic} methodName - name of method to stub
 '  * @param {boolean} [allowNonExistingMethods=false] - if true, then rooibos will only warn if the method did not exist prior to faking
 '  * @returns {Object} - mock that was wired into the real method
-'  */ 
+'  */
 function RBS_BTS_ExpectNone(target, methodName, allowNonExistingMethods = false) as object
   return m.Mock(target, methodName, 0, invalid, invalid, allowNonExistingMethods)
-end function 
+end function
 
 ' /**
 '  * @memberof module:BaseTestSuite
@@ -1445,10 +1445,10 @@ end function
 '  * @param {Dynamic} [returnValue=invalid] - value that the stub method will return when invoked
 '  * @param {boolean} [allowNonExistingMethods=false] - if true, then rooibos will only warn if the method did not exist prior to faking
 '  * @returns {Object} - mock that was wired into the real method
-'  */ 
+'  */
 function RBS_BTS_Expect(target, methodName, expectedInvocations = 1, expectedArgs = invalid, returnValue = invalid, allowNonExistingMethods = false) as object
   return m.Mock(target, methodName, expectedInvocations, expectedArgs, returnValue, allowNonExistingMethods)
-end function 
+end function
 
 ' /**
 '  * @memberof module:BaseTestSuite
@@ -1463,40 +1463,40 @@ end function
 '  * @param {Dynamic} [returnValue=invalid] - value that the stub method will return when invoked
 '  * @param {boolean} [allowNonExistingMethods=false] - if true, then rooibos will only warn if the method did not exist prior to faking
 '  * @returns {Object} - mock that was wired into the real method
-'  */ 
+'  */
 
 function RBS_BTS_Mock(target, methodName, expectedInvocations = 1, expectedArgs = invalid, returnValue = invalid, allowNonExistingMethods = false) as object
   if (type(target) <> "roAssociativeArray")
     m.Fail("could not create Stub provided target was null")
     return {}
   end if
-  
+
   if (m.mocks = invalid)
     m.__mockId = -1
     m.mocks = {}
   end if
   m.__mockId++
-  
+
   if (m.__mockId > 5)
      ? "ERROR ONLY 6 MOCKS PER TEST ARE SUPPORTED!! you're on # " ; m.__mockId
      ? " Method was " ; methodName
      return invalid
   end if
-  
+
   id = stri(m.__mockId).trim()
   fake = m.CreateFake(id, target, methodName, expectedInvocations, expectedArgs, returnValue)
   m.mocks[id] = fake 'this will bind it to m
   if (type(target[methodName]) = "Function" or type(target[methodName]) = "roFunction" or allowNonExistingMethods)
     target[methodName] =  m["MockCallback" + id]
     target.__mocks = m.mocks
-    
+
     if (allowNonExistingMethods)
       ? "WARNING - mocking call " ; methodName; " which did not exist on target object"
     end if
   else
-    ? "ERROR - could not create Mock : method not found  "; target ; "." ; methodName 
+    ? "ERROR - could not create Mock : method not found  "; target ; "." ; methodName
   end if
-  
+
   return fake
 end function
 
@@ -1512,7 +1512,7 @@ end function
 '  * @param {Dynamic} [expectedArgs=invalid] - array containing the arguments we expect the method to be invoked with
 '  * @param {Dynamic} [returnValue=invalid] - value that the stub method will return when invoked
 '  * @returns {Object} - stub that was wired into the real method
-'  */ 
+'  */
 function RBS_BTS_CreateFake(id, target, methodName, expectedInvocations = 1, expectedArgs =invalid, returnValue=invalid ) as object
   expectedArgsValues = []
   hasArgs = expectedArgs <> invalid
@@ -1520,11 +1520,11 @@ function RBS_BTS_CreateFake(id, target, methodName, expectedInvocations = 1, exp
     defaultValue = m.invalidValue
   else
     defaultValue = m.ignoreValue
-  end if 
-  
+  end if
+
   for i = 0 to 9
     if (hasArgs and expectedArgs.count() > i)
-      expectedArgsValues.push(expectedArgs[i])    
+      expectedArgsValues.push(expectedArgs[i])
     else
       expectedArgsValues.push(defaultValue)
     end if
@@ -1533,22 +1533,22 @@ function RBS_BTS_CreateFake(id, target, methodName, expectedInvocations = 1, exp
     id : id,
     target: target,
     methodName: methodName,
-    returnValue: returnValue, 
+    returnValue: returnValue,
     isCalled: false,
     invocations: 0,
     invokedArgs: [invalid, invalid, invalid, invalid, invalid, invalid, invalid, invalid, invalid],
     expectedArgs: expectedArgsValues,
     expectedInvocations: expectedInvocations,
     callback: function (arg1=invalid,  arg2=invalid,  arg3=invalid,  arg4=invalid,  arg5=invalid,  arg6=invalid,  arg7=invalid,  arg8=invalid,  arg9 =invalid)as dynamic
-      ? "FAKE CALLBACK CALLED FOR " ; m.methodName 
+      ? "FAKE CALLBACK CALLED FOR " ; m.methodName
       if (m.allInvokedArgs = invalid)
         m.allInvokedArgs = []
       end if
       m.invokedArgs = [arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ]
-      m.allInvokedArgs.push ([arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ]) 
+      m.allInvokedArgs.push ([arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9 ])
       m.isCalled = true
       m.invocations++
-      
+
       if (type(m.returnValue) = "roAssociativeArray" and m.returnValue.doesExist("multiResult"))
         returnValues = m.returnValue["multiResult"]
         returnIndex = m.invocations -1
@@ -1559,7 +1559,7 @@ function RBS_BTS_CreateFake(id, target, methodName, expectedInvocations = 1, exp
           returnIndex = returnValues.count() -1
           print "Multi return values all used up - repeating last value"
         end if
-          return returnValues[returnIndex] 
+          return returnValues[returnIndex]
         else
           ? "Multi return value was specified; but no array of results were found"
           return invalid
@@ -1578,7 +1578,7 @@ end function
 '  * @function
 '  * @instance
 '  * @description Will check all mocks that have been created to ensure they were invoked the expected amount of times, with the expected args.
-'  */ 
+'  */
 function RBS_BTS_AssertMocks() as void
   if (m.__mockId = invalid ) return
   lastId = int(m.__mockId)
@@ -1592,23 +1592,23 @@ function RBS_BTS_AssertMocks() as void
       for i = 0 to mock.expectedargs.count() -1
         value = mock.invokedArgs[i]
         expected = mock.expectedargs[i]
-        didNotExpectArg = RBS_CMN_IsString(expected) and expected = m.invalidValue 
+        didNotExpectArg = RBS_CMN_IsString(expected) and expected = m.invalidValue
         if (didNotExpectArg)
           expected = invalid
         end if
-        
+
         if ((RBS_CMN_IsString(expected) and not expected = m.ignoreValue) or not m.eqValues(value,expected))
           if (expected = invalid)
             expected = "[INVALID]"
           end if
-          
+
           m.MockFail(methodName, "Expected arg #" + stri(i).trim() + "  to be '" + RBS_CMN_AsString(expected) + "' got '" + RBS_CMN_AsString(value) + "')")
           return
         end if
       end for
      end if
   end for
-  
+
   m.CleanMocks()
 end function
 
@@ -1618,7 +1618,7 @@ end function
 '  * @function
 '  * @instance
 '  * @description Cleans up all tracking data associated with mocks
-'  */ 
+'  */
 function RBS_BTS_CleanMocks() as void
   if m.mocks = invalid return
   for each id in m.mocks
@@ -1634,7 +1634,7 @@ end function
 '  * @function
 '  * @instance
 '  * @description Cleans up all tracking data associated with stubs
-'  */ 
+'  */
 function RBS_BTS_CleanStubs() as void
   if m.stubs = invalid return
   for each id in m.stubs
@@ -1729,7 +1729,7 @@ end function
 
 
 '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-'++ Utility functions! 
+'++ Utility functions!
 '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 '*************************************************************
@@ -1782,7 +1782,7 @@ Function RBS_BTS_rodash_get_(aa, path, default=invalid)
   if (Type(path) = "roInt" or Type(path) = "roInteger" or Type(path) = "Integer")
     path = stri(path).trim()
   end if
-    
+
   if segments = invalid then return default
   result = invalid
 
@@ -1798,24 +1798,24 @@ Function RBS_BTS_rodash_get_(aa, path, default=invalid)
         if not aa.doesExist(key)
           exit while
         end if
-    
+
         value = aa.lookup(key)
-      else 
+      else
         value = invalid
       end if
     else
       if not aa.doesExist(key)
         exit while
       end if
-    
+
       value = aa.lookup(key)
     end if
-    
+
     if segments.count() = 0
       result = value
       exit while
     end if
-    
+
     if type(value) <> "roAssociativeArray" and type(value) <> "roArray" and type(value) <> "roSGNode"
       exit while
     end if

--- a/src/Rooibos_BaseTestSuite.brs
+++ b/src/Rooibos_BaseTestSuite.brs
@@ -8,7 +8,6 @@ function BaseTestSuite() as Object
 
   this = {}
   this.Name               = "BaseTestSuite"
-  this.invalidValue = "#ROIBOS#INVALID_VALUE" ' special value used in mock arguments
   this.ignoreValue = "#ROIBOS#IGNORE_VALUE" ' special value used in mock arguments
   this.isAutoAssertingMocks = true
 
@@ -1592,12 +1591,10 @@ function RBS_BTS_AssertMocks() as void
       for i = 0 to mock.expectedargs.count() -1
         value = mock.invokedArgs[i]
         expected = mock.expectedargs[i]
-        didNotExpectArg = RBS_CMN_IsString(expected) and expected = m.invalidValue
-        if (didNotExpectArg)
-          expected = invalid
-        end if
 
-        if ((RBS_CMN_IsString(expected) and not expected = m.ignoreValue) or not m.eqValues(value,expected))
+        isIgnoreValue = RBS_CMN_IsString(expected) and expected = m.ignoreValue
+
+        if (not isIgnoreValue and not m.eqValues(value,expected))
           if (expected = invalid)
             expected = "[INVALID]"
           end if


### PR DESCRIPTION
The problem: m.ignoreValue constant don't working.

This pull-request will:
- fix ignoreValue issue
- cover empty expectedArgs

Test Spec:
```
'@Only
'@Test reported case
'@Params[52, [52], true]
'@Params[invalid, [invalid], true]
'@Params["42", ["42"], true]
'@Params[42, ["#ROIBOS#IGNORE_VALUE"], true]
'@Params[42, [invalid], false]
'@Params[42, invalid, true]
'@Params[42, [], true]
function assertMocks_test_spec(value, expected, mockPass) as void
    obj = {
        foo: function(arg0) : return arg0 : end function
    }
     m.ExpectOnce(obj, "foo", expected)
    obj.foo(value)
    m.isAutoAssertingMocks = false
    m.AssertMocks()

    isFail = m.currentResult.isFail
    m.currentResult.Reset()
    m.CleanMocks()
    m.AssertEqual(isFail, not mockPass)
end function
```