### PR TITLE
feat: Increase mocks limit to 25 - it is now possible to create up to 25 mocks for a given test suite.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 build
+.env
+
 ###BrightScript specific
 dist/apps
 out/
@@ -37,3 +39,7 @@ frameworkTests/source/tests/rooibosDist.brs
 outRun
 out
 rooibosDist.brs
+
+# Yarn
+yarn.lock
+yarn-error.log

--- a/frameworkTests/source/tests/ExpectTests.brs
+++ b/frameworkTests/source/tests/ExpectTests.brs
@@ -30,8 +30,8 @@ end function
 '@It tests mock count limit
 '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-'@Test mock count limit is 25
-function ET_expect_mockCountLimitToBe25() as void
+'@Test mock count limit at least 25
+function ET_expect_mockCountLimitToBeAtLeast25() as void
 
     interface = {}
 

--- a/frameworkTests/source/tests/ExpectTests.brs
+++ b/frameworkTests/source/tests/ExpectTests.brs
@@ -19,10 +19,33 @@ function ET_expectOnce_valuesBug_reported(expectedValue, expectMockFail) as void
     obj.foo(42)
     m.isAutoAssertingMocks = false
     m.AssertMocks()
-    
+
     isFail = m.currentResult.isFail
     m.currentResult.Reset()
     m.CleanMocks()
-    m.AssertEqual(isFail, expectMockFail)     
+    m.AssertEqual(isFail, expectMockFail) 
+end function
+
+'+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+'@It tests mock count limit
+'+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+'@Test mock count limit is 25
+function ET_expect_mockCountLimitToBe25() as void
+
+    interface = {}
+
+    mockCountLimit = 25 
+    for i = 1 to mockCountLimit step + 1
+        keyName = StrI(i).trim()
+        interface[keyName] = function(arg0) : return arg0 : end function
+
+        expectedArg = "a"
+        expectedReturnValue = "b" 
+        m.ExpectOnce(interface, keyName, [expectedArg], [expectedReturnValue])
+
+        interface[keyName](expectedArg)
+    end for
+
 end function
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,5 +1,5 @@
 import { series } from "gulp";
-import { RooibosProcessor, createProcessorConfig, ProcessorConfig } from "rooibos-cli";
+import { RooibosProcessor, createProcessorConfig } from "rooibos-cli";
 import { MaestroProjectProcessor, createMaestroConfig } from 'maestro-cli-roku';
 
 const concat = require('gulp-concat');

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,6 +1,9 @@
 import { series } from "gulp";
 import { RooibosProcessor, createProcessorConfig } from "rooibos-cli";
 import { MaestroProjectProcessor, createMaestroConfig } from 'maestro-cli-roku';
+import { config } from 'dotenv';
+
+config(__dirname, '.env');
 
 const concat = require('gulp-concat');
 const gulp = require('gulp');

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "del": "^3.0.0",
     "docdash": "^0.4.0",
+    "dotenv": "^8.1.0",
     "glob-all": "^3.1.0",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",

--- a/src/BaseTestSuite.bs
+++ b/src/BaseTestSuite.bs
@@ -1477,8 +1477,8 @@ public function Mock(target, methodName, expectedInvocations = 1, expectedArgs =
   if fake = invalid
     m.__mockId++
     id = stri(m.__mockId).trim()
-    if (m.__mockId > 6)
-      ? "ERROR ONLY 6 MOCKS PER TEST ARE SUPPORTED!! you're on # " ; m.__mockId
+    if (m.__mockId > 25)
+      ? "ERROR ONLY 25 MOCKS PER TEST ARE SUPPORTED!! you're on # " ; m.__mockId
       ? " Method was " ; methodName
       return invalid
     end if
@@ -1771,24 +1771,115 @@ public function MockCallback2(arg1 = invalid, arg2 = invalid, arg3 = invalid, ar
   return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 end function
 
-
 public function MockCallback3(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
   fake = m.__mocks["3"]
   return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 end function
-
 
 public function MockCallback4(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
   fake = m.__mocks["4"]
   return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 end function
 
-
 public function MockCallback5(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
   fake = m.__mocks["5"]
   return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 end function
 
+public function MockCallback6(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["6"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback7(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["7"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback8(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["8"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback9(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["9"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback10(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["10"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback11(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["11"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback12(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["12"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback13(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["13"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback14(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["14"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback15(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["15"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback16(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["16"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback17(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["17"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback18(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["18"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback19(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["19"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback20(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["20"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback21(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["21"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback22(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["22"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback23(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["23"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
+
+public function MockCallback24(arg1 = invalid, arg2 = invalid, arg3 = invalid, arg4 = invalid, arg5 = invalid, arg6 = invalid, arg7 = invalid, arg8 = invalid, arg9 = invalid)as dynamic
+  fake = m.__mocks["24"]
+  return fake.callback(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
+end function
 
 
 '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
- Increases mock count limit
- Removes unused import member in gulpfile.ts
- Adds dotenv dependency to make configuring build easier
- Updates .gitignore