### PR TITLE
Fix - Remove "createNodefile" call duplicate

### DIFF
--- a/bsc-plugin/src/plugin.ts
+++ b/bsc-plugin/src/plugin.ts
@@ -118,8 +118,6 @@ export class RooibosPlugin implements CompilerPlugin {
                 this.session.createNodeFile(event.program, testSuite);
             }
         }
-
-        this.session.createNodeFiles(this._builder.program);
     }
 
     afterProgramTranspile(program: Program, entries: TranspileObj[], editor: AstEditor) {

--- a/framework/src/source/TestRunner.bs
+++ b/framework/src/source/TestRunner.bs
@@ -120,6 +120,11 @@ namespace rooibos
 
       if suiteClass <> invalid
         testSuite = suiteClass()
+        testSuite.global = m.nodeContext.global
+        testSuite.node = m.nodeContext
+        testSuite.top = m.nodeContext.top
+        testSuite.scene = m.nodeContext.global.testsScene
+        testSuite.catchCrashes = m.config.catchCrashes
       end if
 
       if testSuite <> invalid


### PR DESCRIPTION
When you run a test with sgnode annotation the generate node is not filled, it seems solve when you remove the duplicate call of method "createNodeFile"