### PR TITLE
[FIX] Renames global timer var for uniqueness

### DIFF
--- a/framework/src/source/Test.bs
+++ b/framework/src/source/Test.bs
@@ -42,8 +42,8 @@ namespace rooibos
     end function
 
     function run()
-      timer = createObject("roTimespan")
-      timer.mark()
+      rooibosTimer = createObject("roTimespan")
+      rooibosTimer.mark()
 
       if m.isParamTest
         m.runParamsTest()
@@ -51,7 +51,7 @@ namespace rooibos
         m.testSuite[m.funcName]()
       end if
 
-      m.result.time = timer.totalMilliseconds()
+      m.result.time = rooibosTimer.totalMilliseconds()
 
     end function
 

--- a/framework/src/source/TestRunner.bs
+++ b/framework/src/source/TestRunner.bs
@@ -44,8 +44,8 @@ namespace rooibos
     '  */
     public function run()
 
-      timer = createObject("roTimespan")
-      timer.mark()
+      rooibosTimer = createObject("roTimespan")
+      rooibosTimer.mark()
       suiteNames = m.runtimeConfig.getAllTestSuitesNames()
       isFailed = false
       failedText = ""
@@ -95,7 +95,7 @@ namespace rooibos
         m.nodeContext.global.testsScene.failedText = "No tests were found"
       end if
 
-      m.stats.time = timer.totalMilliseconds()
+      m.stats.time = rooibosTimer.totalMilliseconds()
 
       m.testReporter.reportResults(m.stats)
 


### PR DESCRIPTION
**Problem**

The `timer` variable collides with app code in a few projects which then requires some build time string replacements. 

**Solution**

Prefix the `timer` variable to make it more unique.