### PR TITLE
Fix coverage files import

### DIFF
--- a/bsc-plugin/src/lib/rooibos/FileFactory.ts
+++ b/bsc-plugin/src/lib/rooibos/FileFactory.ts
@@ -4,11 +4,9 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 
-const frameworkSrc = path.resolve(__dirname, '../../../../framework/src/source');
-
 export class FileFactory {
-    private coverageComponentXmlTemplate = fs.readFileSync(path.join(frameworkSrc, 'CodeCoverage.xml'), 'utf8');
-    private coverageComponentBrsTemplate = fs.readFileSync(path.join(frameworkSrc, 'CodeCoverage.brs'), 'utf8');
+    private coverageComponentXmlTemplate;
+    private coverageComponentBrsTemplate;
 
     constructor(
         private options?: {
@@ -25,6 +23,9 @@ export class FileFactory {
                 this.options.frameworkSourcePath = s`${__dirname}/../framework`;
             }
         }
+
+        this.coverageComponentXmlTemplate = fs.readFileSync(path.join(this.options.frameworkSourcePath, 'CodeCoverage.xml'), 'utf8');
+        this.coverageComponentBrsTemplate = fs.readFileSync(path.join(this.options.frameworkSourcePath, 'CodeCoverage.brs'), 'utf8');
     }
 
     private frameworkFileNames = [

--- a/bsc-plugin/src/plugin.ts
+++ b/bsc-plugin/src/plugin.ts
@@ -72,8 +72,10 @@ export class RooibosPlugin implements CompilerPlugin {
         }
 
         const defaultCoverageExcluded = [
-            '!**/*.spec.bs',
-            '!**/roku_modules/**/*'
+            '**/*.spec.bs',
+            '**/roku_modules/**/*',
+            '**/source/main.bs',
+            '**/source/rooibos/**/*'
         ];
 
         // Set default coverage exclusions, or merge with defaults if available.
@@ -174,12 +176,11 @@ export class RooibosPlugin implements CompilerPlugin {
             return true;
         } else {
             for (let filter of this.config.coverageExcludedFiles) {
-                if (minimatch(file.pathAbsolute, filter)) {
+                if (minimatch(file.pkgPath, filter)) {
                     return false;
                 }
             }
         }
-        // console.log('including ', file.pkgPath);
         return true;
     }
 }

--- a/bsc-plugin/src/plugin.ts
+++ b/bsc-plugin/src/plugin.ts
@@ -71,11 +71,16 @@ export class RooibosPlugin implements CompilerPlugin {
                 '!**/roku_modules/**/*'];
         }
 
+        const defaultCoverageExcluded = [
+            '!**/*.spec.bs',
+            '!**/roku_modules/**/*'
+        ];
+
+        // Set default coverage exclusions, or merge with defaults if available.
         if (config.coverageExcludedFiles === undefined) {
-            config.coverageExcludedFiles = [
-                '**/*.spec.bs',
-                '**/roku_modules/**/*'
-            ];
+            config.coverageExcludedFiles = defaultCoverageExcluded;
+        } else {
+            config.coverageExcludedFiles.push(...defaultCoverageExcluded);
         }
 
         return config;


### PR DESCRIPTION
- Fixes how framework coverage files are imported
- Merges user-defined code coverage exclusions with default list
- Uses `file.pkgPath` instead of deprecated `file.absolutePath` to decide code coverage exclusion. This is to support both development mode when the plugin is a `.ts` and production mode when the plugin has been bundled.