### PR TITLE
Proposed fix for anonymous callback crash

### DIFF
--- a/bsc-plugin/src/lib/rooibos/TestGroup.ts
+++ b/bsc-plugin/src/lib/rooibos/TestGroup.ts
@@ -77,7 +77,7 @@ export class TestGroup extends TestBlock {
                                 overrideAstTranspile(editor, expressionStatement, '\n' + undent`
                                     m.currentAssertLineNumber = ${callExpression.range.start.line}
                                     ${callExpression.transpile(transpileState).join('')}
-                                    ${noEarlyExit ? '' : 'if m.currentResult.isFail then return invalid'}
+                                    ${noEarlyExit ? '' : 'if m.currentResult?.isFail = true then m.done() : return invalid'}
                                 ` + '\n');
                             }
                         }

--- a/bsc-plugin/src/plugin.spec.ts
+++ b/bsc-plugin/src/plugin.spec.ts
@@ -605,14 +605,14 @@ describe('RooibosPlugin', () => {
                     m._expectCalled(m.thing, "callFunc", m, "m.thing", [
                     "getFunction"
                     ])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "callFunc", m, "m.thing", [
                     "getFunction"
                     ], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
@@ -621,7 +621,7 @@ describe('RooibosPlugin', () => {
                     "a"
                     "b"
                     ])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 9
@@ -630,7 +630,7 @@ describe('RooibosPlugin', () => {
                     "a"
                     "b"
                     ], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
 
@@ -655,12 +655,12 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     m.currentAssertLineNumber = 6
                     m._expectCalled(m.thing, "getFunctionField", m, "m.thing", invalid)
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "getFunctionField", m, "m.thing", invalid, "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
 
@@ -687,12 +687,12 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     m.currentAssertLineNumber = 6
                     m._expectCalled(m.thing, "getFunction", m, "m.thing", [])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "getFunction", m, "m.thing", [], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
@@ -700,7 +700,7 @@ describe('RooibosPlugin', () => {
                     "arg1"
                     "arg2"
                     ])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 9
@@ -708,7 +708,7 @@ describe('RooibosPlugin', () => {
                     "arg1"
                     "arg2"
                     ], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
             it('does not break when validating again after a transpile', async () => {
@@ -735,12 +735,12 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     m.currentAssertLineNumber = 6
                     m._expectCalled(m.thing, "getFunction", m, "m.thing", [])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "getFunction", m, "m.thing", [], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
@@ -748,7 +748,7 @@ describe('RooibosPlugin', () => {
                     "arg1"
                     "arg2"
                     ])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 9
@@ -756,7 +756,7 @@ describe('RooibosPlugin', () => {
                     "arg1"
                     "arg2"
                     ], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
 
@@ -792,7 +792,7 @@ describe('RooibosPlugin', () => {
                     m.assertEqual(b, {
                     someValue: "value"
                     })
-                    if m.currentResult.isFail then return invalid`);
+                    if m.currentResult?.isFail = true then m.done() : return invalid`);
             });
 
             it('correctly transpiles function invocations - simple object', async () => {
@@ -823,12 +823,12 @@ describe('RooibosPlugin', () => {
 
                     m.currentAssertLineNumber = 7
                     m._expectCalled(item, "getFunction", item, "item", [])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
                     m._expectCalled(item, "getFunction", item, "item", [], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 9
@@ -836,7 +836,7 @@ describe('RooibosPlugin', () => {
                     "arg1"
                     "arg2"
                     ])
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 10
@@ -844,7 +844,7 @@ describe('RooibosPlugin', () => {
                     "arg1"
                     "arg2"
                     ], "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
         });
@@ -1015,22 +1015,22 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     m.currentAssertLineNumber = 6
                     m._expectNotCalled(m.thing, "callFunc", m, "m.thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 7
                     m._expectNotCalled(m.thing, "callFunc", m, "m.thing", "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
                     m._expectNotCalled(m.thing, "callFunc", m, "m.thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 9
                     m._expectNotCalled(m.thing, "callFunc", m, "m.thing", "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
 
@@ -1058,12 +1058,12 @@ describe('RooibosPlugin', () => {
 
                     m.currentAssertLineNumber = 7
                     m._expectNotCalled(thing, "callFunc", thing, "thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
                     m._expectNotCalled(thing, "callFunc", thing, "thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
                 //verify original code does not remain modified after the transpile cycle
                 const testMethod = ((file.ast.statements[0] as ClassStatement).memberMap['_'] as ClassMethodStatement);
@@ -1100,7 +1100,7 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     m.currentAssertLineNumber = 6
                     m._expectNotCalled(m.thing, "getFunctionField", m, "m.thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
                 //verify original code does not remain modified after the transpile cycle
                 const testMethod = ((file.ast.statements[0] as ClassStatement).memberMap['_'] as ClassMethodStatement);
@@ -1134,22 +1134,22 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     m.currentAssertLineNumber = 6
                     m._expectNotCalled(m.thing, "getFunction", m, "m.thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 7
                     m._expectNotCalled(m.thing, "getFunction", m, "m.thing", "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
                     m._expectNotCalled(m.thing, "getFunction", m, "m.thing")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 9
                     m._expectNotCalled(m.thing, "getFunction", m, "m.thing", "return")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
 
@@ -1179,12 +1179,12 @@ describe('RooibosPlugin', () => {
 
                     m.currentAssertLineNumber = 7
                     m._expectNotCalled(item, "getFunction", item, "item")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                     m.currentAssertLineNumber = 8
                     m._expectNotCalled(item, "getFunction", item, "item")
-                    if m.currentResult.isFail then return invalid
+                    if m.currentResult?.isFail = true then m.done() : return invalid
                 `);
             });
         });
@@ -1369,12 +1369,12 @@ describe('RooibosPlugin', () => {
 
                 m.currentAssertLineNumber = 7
                 m._expectNotCalled(item, "getFunction", item, "item")
-                if m.currentResult.isFail then return invalid
+                if m.currentResult?.isFail = true then m.done() : return invalid
 
 
                 m.currentAssertLineNumber = 8
                 m._expectNotCalled(item, "getFunction", item, "item")
-                if m.currentResult.isFail then return invalid
+                if m.currentResult?.isFail = true then m.done() : return invalid
             `);
 
             let a = getContents('rooibos/RuntimeConfig.brs');

--- a/tests/src/source/NodeExample.spec.bs
+++ b/tests/src/source/NodeExample.spec.bs
@@ -44,6 +44,30 @@ namespace tests
       m.timer.observeFieldScoped("fire", "OnTimer")
       m.timer.control = "start"
     end function
+
+    @async(1000)
+    @it("asynchronous call to anonymous function")
+    @params("jon", 40)
+    @params("ringo", 23)
+    @params("ringo", 50)
+    @params("ringo", 24)
+    @params("george", 40)
+    @params("paul", 50)
+    function _(name, age)
+      m.age = age
+
+      callback = function()
+        ? "*** timer triggering anonymous callback function"
+        m.testSuite.assertTrue(m.testSuite.age >= 18)
+        m.testSuite.done()
+      end function
+      callback = callback.toStr().tokenize(" ").peek()
+
+      m.timer = createObject("roSGNode", "Timer")
+      m.timer.duration = 0.1
+      m.timer.observeFieldScoped("fire", callback)
+      m.timer.control = "start"
+    end function
   end class
 end namespace
 


### PR DESCRIPTION
Proposed fix for crash when testing asynchronous callbacks to anonymous functions. This would enable asserts in the anonymous functions giving us greater flexibility with our test development. Includes a test that demonstrates the issue.