### PR TITLE
Update FileFactory.ts to move status labels down for better visibility

### DIFF
--- a/bsc-plugin/src/lib/rooibos/FileFactory.ts
+++ b/bsc-plugin/src/lib/rooibos/FileFactory.ts
@@ -90,7 +90,7 @@ export class FileFactory {
                 <children>
                     <Rectangle id="statusBackground" color="#444444" width="1920" height="1080" />
                     <LayoutGroup translation="[960, 540]" vertAlignment="center" >
-                        <Label id="statusLabel" text='Rooibos is running tests' />
+                        <Label id="statusLabel" text='Rooibos is running tests' width="1800" />
                         <Label id="failedLabel" text="" translation="[0, 100]" width="1800" wrap="true" maxLines="15"/>
                     </LayoutGroup>
                 </children>

--- a/bsc-plugin/src/lib/rooibos/FileFactory.ts
+++ b/bsc-plugin/src/lib/rooibos/FileFactory.ts
@@ -89,7 +89,7 @@ export class FileFactory {
 
                 <children>
                     <Rectangle id="statusBackground" color="#444444" width="1920" height="1080" />
-                    <LayoutGroup translation="[960, 540]" vertAlignment="center" >
+                    <LayoutGroup translation="[960, 540]" vertAlignment="center"  horizAlignment="center">
                         <Label id="statusLabel" text='Rooibos is running tests' width="1800" />
                         <Label id="failedLabel" text="" translation="[0, 100]" width="1800" wrap="true" maxLines="15"/>
                     </LayoutGroup>

--- a/bsc-plugin/src/lib/rooibos/FileFactory.ts
+++ b/bsc-plugin/src/lib/rooibos/FileFactory.ts
@@ -89,8 +89,10 @@ export class FileFactory {
 
                 <children>
                     <Rectangle id="statusBackground" color="#444444" width="1920" height="1080" />
-                    <Label id="statusLabel" text='Rooibos is running tests' />
-                    <Label id="failedLabel" text="" translation="[0, 100]" width="1800" wrap="true" maxLines="15"/>
+                    <LayoutGroup translation="[960, 540]" vertAlignment="center" >
+                        <Label id="statusLabel" text='Rooibos is running tests' />
+                        <Label id="failedLabel" text="" translation="[0, 100]" width="1800" wrap="true" maxLines="15"/>
+                    </LayoutGroup>
                 </children>
             </component>
         `;


### PR DESCRIPTION
Before:
![image](https://github.com/georgejecook/rooibos/assets/9591618/ed9d15dc-56b3-44df-820a-13c3afbd7161)

After:
![image](https://github.com/georgejecook/rooibos/assets/9591618/158ecf64-ef84-486b-8990-0a4113199db6)