### PR TITLE
Fix Rooibos_init injection causing duplicate calls

### DIFF
--- a/bsc-plugin/src/lib/rooibos/RooibosSession.ts
+++ b/bsc-plugin/src/lib/rooibos/RooibosSession.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import type { BrsFile, BscFile, ClassStatement, FunctionStatement, NamespaceStatement, Program, ProgramBuilder, Scope, Statement } from 'brighterscript';
-import { isBrsFile, ParseMode } from 'brighterscript';
+import { isBrsFile, isCallExpression, isVariableExpression, ParseMode, WalkMode } from 'brighterscript';
 import type { AstEditor } from 'brighterscript/dist/astUtils/AstEditor';
 import type { RooibosConfig } from './RooibosConfig';
 import { SessionInfo } from './RooibosSessionInfo';
@@ -88,7 +88,12 @@ export class RooibosSession {
             }
         }
         if (mainFunction) {
-            editor.addToArray(mainFunction.func.body.statements, 0, new RawCodeStatement(`Rooibos_init("${this.config?.testSceneName ?? 'RooibosScene'}")`));
+            const initCall = mainFunction.func.body.findChild(f => isCallExpression(f) && isVariableExpression(f.callee) && f.callee.name.text.toLowerCase() === 'rooibos_init', {
+                walkMode: WalkMode.visitAllRecursive
+            });
+            if (!initCall) {
+                editor.addToArray(mainFunction.func.body.statements, 0, new RawCodeStatement(`Rooibos_init("${this.config?.testSceneName ?? 'RooibosScene'}")`));
+            }
         }
     }
     addLaunchHookFileIfNotPresent() {

--- a/bsc-plugin/src/lib/rooibos/RooibosSession.ts
+++ b/bsc-plugin/src/lib/rooibos/RooibosSession.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import type { BrsFile, BscFile, ClassStatement, FunctionStatement, NamespaceStatement, Program, ProgramBuilder, Scope, Statement } from 'brighterscript';
-import { isBrsFile, ParseMode, util } from 'brighterscript';
+import { isBrsFile, ParseMode } from 'brighterscript';
 import type { AstEditor } from 'brighterscript/dist/astUtils/AstEditor';
 import type { RooibosConfig } from './RooibosConfig';
 import { SessionInfo } from './RooibosSessionInfo';
@@ -10,7 +10,6 @@ import type { FileFactory } from './FileFactory';
 import type { TestSuite } from './TestSuite';
 import { diagnosticErrorNoMainFound as diagnosticWarnNoMainFound, diagnosticNoStagingDir } from '../utils/Diagnostics';
 import undent from 'undent';
-import { BrsTranspileState } from 'brighterscript/dist/parser/BrsTranspileState';
 import * as fsExtra from 'fs-extra';
 import type { MockUtil } from './MockUtil';
 


### PR DESCRIPTION
The rooibos plugin will create a main function if it doesn't exist. And if it does, it will inject a `Rooibos_init(...)` call as its first statement.

However, the way this is set up creates a duplicate call when both the function and statement already exist in the original source code. This causes problems when you need your project to control when/where it's called (i.e. to support sockets, as seen in #212).

This PR helps by detecting if such a call is already made, and only inject it if it's not found.