### PR TITLE
Updated default global excluded files

### DIFF
--- a/bsc-plugin/src/plugin.ts
+++ b/bsc-plugin/src/plugin.ts
@@ -104,7 +104,6 @@ export class RooibosPlugin implements CompilerPlugin {
 
         const defaultGlobalMethodMockingExcluded = [
             '**/*.spec.bs',
-            '**/roku_modules/**/*',
             '**/source/main.bs',
             '**/source/rooibos/**/*'
         ];


### PR DESCRIPTION
Removed `roku_modules` from the default exclude list for global mocking and stubbing.