### PR TITLE
Reduce raw code statements

### DIFF
--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -4,14 +4,11 @@ import { expect } from 'chai';
 import PluginInterface from 'brighterscript/dist/PluginInterface';
 import * as fsExtra from 'fs-extra';
 import { RooibosPlugin } from '../../plugin';
+import undent from 'undent';
 
 let tmpPath = s`${process.cwd()}/tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
 let _stagingFolderPath = s`${tmpPath}/staging`;
-
-function trimLeading(text: string) {
-    return text.split('\n').map((line) => line.trimStart()).join('\n');
-}
 
 describe('RooibosPlugin', () => {
     let program: Program;
@@ -21,7 +18,8 @@ describe('RooibosPlugin', () => {
 
     function getContents(filename: string) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        return trimLeading(fsExtra.readFileSync(s`${_stagingFolderPath}/${filename}`).toString());
+        let contents = fsExtra.readFileSync(s`${_stagingFolderPath}/${filename}`).toString();
+        return undent(contents);
     }
 
     describe('CodeCoverageProcessor', () => {
@@ -68,169 +66,6 @@ describe('RooibosPlugin', () => {
             // in `beforeEach`. This is because the compiler normally skips processing .brs files and copies them as-is.
             it('adds code coverage to a brs file', async () => {
                 program.setFile('source/code.brs', `
-                function new(a1, a2)
-                c = 0
-                text = ""
-                    for i = 0 to 10
-                        text = text + "hello"
-                        c++
-                        c += 1
-                        if c = 2
-                            ? "is true"
-                        end if
-
-                        if c = 3
-                            ? "free"
-                        else
-                            ? "not free"
-                        end if
-                    end for
-                end function
-            `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = `function new(a1, a2)
-RBS_CC_1_reportLine(2, 1)
-c = 0
-RBS_CC_1_reportLine(3, 1)
-text = ""
-RBS_CC_1_reportLine(4, 1): for i = 0 to 10
-RBS_CC_1_reportLine(5, 1)
-text = text + "hello"
-RBS_CC_1_reportLine(6, 1)
-c++
-RBS_CC_1_reportLine(7, 1)
-c += 1
-if RBS_CC_1_reportLine(8, 3) and c = 2
-RBS_CC_1_reportLine(9, 1)
-? "is true"
-end if
-if RBS_CC_1_reportLine(12, 3) and c = 3
-RBS_CC_1_reportLine(13, 1)
-? "free"
-else
-RBS_CC_1_reportLine(14, 3)
-RBS_CC_1_reportLine(15, 1)
-? "not free"
-end if
-end for
-end function
-
-function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-if m.global = invalid
-'? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
-return true
-else
-if m._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-if m.global._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-m.global.addFields({
-"_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-})
-end if
-m._rbs_ccn = m.global._rbs_ccn
-end if
-end if
-
-m._rbs_ccn.entry = {"f":"1", "l":stri(lineNumber), "r":reportType}
-return true
-end function
-`;
-                expect(a).to.equal(b);
-
-            });
-        });
-        describe('basic bs tests', () => {
-
-            it('adds code coverage to a bs file', async () => {
-                program.setFile('source/code.bs', `
-                function new(a1, a2)
-                c = 0
-                text = ""
-                    for i = 0 to 10
-                        text = text + "hello"
-                        c++
-                        c += 1
-                        if c = 2
-                            ? "is true"
-                        end if
-
-                        if c = 3
-                            ? "free"
-                        else
-                            ? "not free"
-                        end if
-                    end for
-                end function
-            `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = `function new(a1, a2)
-RBS_CC_1_reportLine(2, 1)
-c = 0
-RBS_CC_1_reportLine(3, 1)
-text = ""
-RBS_CC_1_reportLine(4, 1): for i = 0 to 10
-RBS_CC_1_reportLine(5, 1)
-text = text + "hello"
-RBS_CC_1_reportLine(6, 1)
-c++
-RBS_CC_1_reportLine(7, 1)
-c += 1
-if RBS_CC_1_reportLine(8, 3) and c = 2
-RBS_CC_1_reportLine(9, 1)
-? "is true"
-end if
-if RBS_CC_1_reportLine(12, 3) and c = 3
-RBS_CC_1_reportLine(13, 1)
-? "free"
-else
-RBS_CC_1_reportLine(14, 3)
-RBS_CC_1_reportLine(15, 1)
-? "not free"
-end if
-end for
-end function
-
-function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-if m.global = invalid
-'? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
-return true
-else
-if m._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-if m.global._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-m.global.addFields({
-"_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-})
-end if
-m._rbs_ccn = m.global._rbs_ccn
-end if
-end if
-
-m._rbs_ccn.entry = {"f":"1", "l":stri(lineNumber), "r":reportType}
-return true
-end function
-`;
-                expect(a).to.equal(b);
-
-            });
-        });
-
-        describe('basic tests', () => {
-
-            it('adds code coverage to a bs file', async () => {
-                program.setFile('source/code.bs', `
-                class BasicClass
-                    private field1
-                    public field2
-
                     function new(a1, a2)
                     c = 0
                     text = ""
@@ -248,87 +83,262 @@ end function
                                 ? "not free"
                             end if
                         end for
-
                     end function
-
-
-                end class
-            `);
+                `);
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
                 let a = getContents('source/code.brs');
-                let b = `function __BasicClass_builder()
-instance = {}
-instance.new = function(a1, a2)
-m.field1 = invalid
-m.field2 = invalid
-RBS_CC_1_reportLine(6, 1)
-c = 0
-RBS_CC_1_reportLine(7, 1)
-text = ""
-RBS_CC_1_reportLine(8, 1): for i = 0 to 10
-RBS_CC_1_reportLine(9, 1)
-text = text + "hello"
-RBS_CC_1_reportLine(10, 1)
-c++
-RBS_CC_1_reportLine(11, 1)
-c += 1
-if RBS_CC_1_reportLine(12, 3) and c = 2
-RBS_CC_1_reportLine(13, 1)
-? "is true"
-end if
-if RBS_CC_1_reportLine(16, 3) and c = 3
-RBS_CC_1_reportLine(17, 1)
-? "free"
-else
-RBS_CC_1_reportLine(18, 3)
-RBS_CC_1_reportLine(19, 1)
-? "not free"
-end if
-end for
-end function
-return instance
-end function
-function BasicClass(a1, a2)
-instance = __BasicClass_builder()
-instance.new(a1, a2)
-return instance
-end function
+                let b = undent(`
+                    function new(a1, a2)
+                        RBS_CC_1_reportLine(2, 1)
+                        c = 0
+                        RBS_CC_1_reportLine(3, 1)
+                        text = ""
+                        RBS_CC_1_reportLine(4, 1): for i = 0 to 10
+                            RBS_CC_1_reportLine(5, 1)
+                            text = text + "hello"
+                            RBS_CC_1_reportLine(6, 1)
+                            c++
+                            RBS_CC_1_reportLine(7, 1)
+                            c += 1
+                            if RBS_CC_1_reportLine(8, 3) and c = 2
+                                RBS_CC_1_reportLine(9, 1)
+                                ? "is true"
+                            end if
+                            if RBS_CC_1_reportLine(12, 3) and c = 3
+                                RBS_CC_1_reportLine(13, 1)
+                                ? "free"
+                            else
+                                RBS_CC_1_reportLine(14, 3)
+                                RBS_CC_1_reportLine(15, 1)
+                                ? "not free"
+                            end if
+                        end for
+                    end function
 
-function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-if m.global = invalid
-'? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
-return true
-else
-if m._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-if m.global._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-m.global.addFields({
-"_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-})
-end if
-m._rbs_ccn = m.global._rbs_ccn
-end if
-end if
+                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                        if m.global = invalid
+                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                            return true
+                        else
+                            if m._rbs_ccn = invalid
+                                '? "Coverage maps are not created - creating now"
+                                if m.global._rbs_ccn = invalid
+                                    '? "Coverage maps are not created - creating now"
+                                    m.global.addFields({
+                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
+                                    })
+                                end if
+                                m._rbs_ccn = m.global._rbs_ccn
+                            end if
+                        end if
+                        m._rbs_ccn.entry = {
+                            "f": "1"
+                            "l": stri(lineNumber)
+                            "r": reportType
+                        }
+                        return true
+                    end function
+                `);
+                expect(a).to.equal(b);
 
-m._rbs_ccn.entry = {"f":"1", "l":stri(lineNumber), "r":reportType}
-return true
-end function
-`;
+            });
+        });
+        describe('basic bs tests', () => {
+
+            it('adds code coverage to a bs file', async () => {
+                program.setFile('source/code.bs', `
+                    function new(a1, a2)
+                    c = 0
+                    text = ""
+                        for i = 0 to 10
+                            text = text + "hello"
+                            c++
+                            c += 1
+                            if c = 2
+                                ? "is true"
+                            end if
+
+                            if c = 3
+                                ? "free"
+                            else
+                                ? "not free"
+                            end if
+                        end for
+                    end function
+                `);
+                program.validate();
+                expect(program.getDiagnostics()).to.be.empty;
+                await builder.transpile();
+                let a = getContents('source/code.brs');
+                let b = undent(`
+                    function new(a1, a2)
+                        RBS_CC_1_reportLine(2, 1)
+                        c = 0
+                        RBS_CC_1_reportLine(3, 1)
+                        text = ""
+                        RBS_CC_1_reportLine(4, 1): for i = 0 to 10
+                            RBS_CC_1_reportLine(5, 1)
+                            text = text + "hello"
+                            RBS_CC_1_reportLine(6, 1)
+                            c++
+                            RBS_CC_1_reportLine(7, 1)
+                            c += 1
+                            if RBS_CC_1_reportLine(8, 3) and c = 2
+                                RBS_CC_1_reportLine(9, 1)
+                                ? "is true"
+                            end if
+                            if RBS_CC_1_reportLine(12, 3) and c = 3
+                                RBS_CC_1_reportLine(13, 1)
+                                ? "free"
+                            else
+                                RBS_CC_1_reportLine(14, 3)
+                                RBS_CC_1_reportLine(15, 1)
+                                ? "not free"
+                            end if
+                        end for
+                    end function
+
+                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                        if m.global = invalid
+                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                            return true
+                        else
+                            if m._rbs_ccn = invalid
+                                '? "Coverage maps are not created - creating now"
+                                if m.global._rbs_ccn = invalid
+                                    '? "Coverage maps are not created - creating now"
+                                    m.global.addFields({
+                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
+                                    })
+                                end if
+                                m._rbs_ccn = m.global._rbs_ccn
+                            end if
+                        end if
+                        m._rbs_ccn.entry = {
+                            "f": "1"
+                            "l": stri(lineNumber)
+                            "r": reportType
+                        }
+                        return true
+                    end function
+                `);
+                expect(a).to.equal(b);
+
+            });
+        });
+
+        describe('basic tests', () => {
+
+            it('adds code coverage to a bs file', async () => {
+                program.setFile('source/code.bs', `
+                    class BasicClass
+                        private field1
+                        public field2
+
+                        function new(a1, a2)
+                        c = 0
+                        text = ""
+                            for i = 0 to 10
+                                text = text + "hello"
+                                c++
+                                c += 1
+                                if c = 2
+                                    ? "is true"
+                                end if
+
+                                if c = 3
+                                    ? "free"
+                                else
+                                    ? "not free"
+                                end if
+                            end for
+
+                        end function
+
+
+                    end class
+                `);
+                program.validate();
+                expect(program.getDiagnostics()).to.be.empty;
+                await builder.transpile();
+                let a = getContents('source/code.brs');
+                let b = undent(`
+                function __BasicClass_builder()
+                    instance = {}
+                    instance.new = function(a1, a2)
+                        m.field1 = invalid
+                        m.field2 = invalid
+                        RBS_CC_1_reportLine(6, 1)
+                        c = 0
+                        RBS_CC_1_reportLine(7, 1)
+                        text = ""
+                        RBS_CC_1_reportLine(8, 1): for i = 0 to 10
+                            RBS_CC_1_reportLine(9, 1)
+                            text = text + "hello"
+                            RBS_CC_1_reportLine(10, 1)
+                            c++
+                            RBS_CC_1_reportLine(11, 1)
+                            c += 1
+                            if RBS_CC_1_reportLine(12, 3) and c = 2
+                                RBS_CC_1_reportLine(13, 1)
+                                ? "is true"
+                            end if
+                            if RBS_CC_1_reportLine(16, 3) and c = 3
+                                RBS_CC_1_reportLine(17, 1)
+                                ? "free"
+                            else
+                                RBS_CC_1_reportLine(18, 3)
+                                RBS_CC_1_reportLine(19, 1)
+                                ? "not free"
+                            end if
+                        end for
+                    end function
+                    return instance
+                end function
+                function BasicClass(a1, a2)
+                    instance = __BasicClass_builder()
+                    instance.new(a1, a2)
+                    return instance
+                end function
+
+                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                    if m.global = invalid
+                        '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                        return true
+                    else
+                        if m._rbs_ccn = invalid
+                            '? "Coverage maps are not created - creating now"
+                            if m.global._rbs_ccn = invalid
+                                '? "Coverage maps are not created - creating now"
+                                m.global.addFields({
+                                    "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
+                                })
+                            end if
+                            m._rbs_ccn = m.global._rbs_ccn
+                        end if
+                    end if
+                    m._rbs_ccn.entry = {
+                        "f": "1"
+                        "l": stri(lineNumber)
+                        "r": reportType
+                    }
+                    return true
+                end function
+                `);
                 expect(a).to.equal(b);
             });
 
             it('correctly transpiles some statements', async () => {
                 const source = `sub foo()
-    x = function(y)
-        if (true) then
-            return 1
-        end if
-        return 0
-    end function
-end sub`;
+                    x = function(y)
+                        if (true) then
+                            return 1
+                        end if
+                        return 0
+                    end function
+                end sub`;
 
                 program.setFile('source/code.bs', source);
                 program.validate();
@@ -336,39 +346,43 @@ end sub`;
                 await builder.transpile();
 
                 let a = getContents('source/code.brs');
-                let b = `sub foo()
-RBS_CC_1_reportLine(1, 1)
-x = function(y)
-if RBS_CC_1_reportLine(2, 3) and (true) then
-RBS_CC_1_reportLine(3, 1)
-return 1
-end if
-RBS_CC_1_reportLine(5, 1)
-return 0
-end function
-end sub
+                let b = undent(`
+                    sub foo()
+                        RBS_CC_1_reportLine(1, 1)
+                        x = function(y)
+                            if RBS_CC_1_reportLine(2, 3) and (true) then
+                                RBS_CC_1_reportLine(3, 1)
+                                return 1
+                            end if
+                            RBS_CC_1_reportLine(5, 1)
+                            return 0
+                        end function
+                    end sub
 
-function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-if m.global = invalid
-'? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
-return true
-else
-if m._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-if m.global._rbs_ccn = invalid
-'? "Coverage maps are not created - creating now"
-m.global.addFields({
-"_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-})
-end if
-m._rbs_ccn = m.global._rbs_ccn
-end if
-end if
-
-m._rbs_ccn.entry = {"f":"1", "l":stri(lineNumber), "r":reportType}
-return true
-end function
-`;
+                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                        if m.global = invalid
+                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                            return true
+                        else
+                            if m._rbs_ccn = invalid
+                                '? "Coverage maps are not created - creating now"
+                                if m.global._rbs_ccn = invalid
+                                    '? "Coverage maps are not created - creating now"
+                                    m.global.addFields({
+                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
+                                    })
+                                end if
+                                m._rbs_ccn = m.global._rbs_ccn
+                            end if
+                        end if
+                        m._rbs_ccn.entry = {
+                            "f": "1"
+                            "l": stri(lineNumber)
+                            "r": reportType
+                        }
+                        return true
+                    end function
+                `);
 
                 expect(a).to.equal(b);
             });
@@ -376,13 +390,13 @@ end function
 
         it('excludes files from coverage', async () => {
             const source = `sub foo()
-        x = function(y)
-            if (true) then
-                return 1
-            end if
-            return 0
-        end function
-    end sub`;
+                x = function(y)
+                    if (true) then
+                        return 1
+                    end if
+                    return 0
+                end function
+            end sub`;
 
             program.setFile('source/code.coverageExcluded.bs', source);
             program.validate();
@@ -390,14 +404,16 @@ end function
             await builder.transpile();
 
             let a = getContents('source/code.coverageExcluded.brs');
-            let b = `sub foo()
-x = function(y)
-if (true) then
-return 1
-end if
-return 0
-end function
-end sub`;
+            let b = undent(`
+                sub foo()
+                    x = function(y)
+                        if (true) then
+                            return 1
+                        end if
+                        return 0
+                    end function
+                end sub
+            `);
 
             expect(a).to.equal(b);
         });

--- a/bsc-plugin/src/lib/rooibos/MockUtil.spec.ts
+++ b/bsc-plugin/src/lib/rooibos/MockUtil.spec.ts
@@ -10,22 +10,15 @@ let tmpPath = s`${process.cwd()}/tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
 let _stagingFolderPath = s`${tmpPath}/staging`;
 
-function trimLeading(text: string) {
-    return text.split('\n').map((line) => line.trimStart()).join('\n');
-}
-
 describe('MockUtil', () => {
     let program: Program;
     let builder: ProgramBuilder;
     let plugin: RooibosPlugin;
     let options;
 
-    function getContents(filename: string, trim = true) {
+    function getContents(filename: string) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         let contents = fsExtra.readFileSync(s`${_stagingFolderPath}/${filename}`).toString();
-        if (trim) {
-            return trimLeading(contents);
-        }
         return contents;
     }
 
@@ -81,7 +74,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     function sayHello(a1, a2)
                         __stubs_globalAa = getGlobalAa()
@@ -118,7 +111,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     function sayHello(a1, a2)
                         __stubs_globalAa = getGlobalAa()
@@ -158,7 +151,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     Sub RedLines_SetRulerLines(rulerLines)
                         __stubs_globalAa = getGlobalAa()
@@ -209,7 +202,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     sub sayHello(a1, a2)
                         __stubs_globalAa = getGlobalAa()
@@ -246,7 +239,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     function person_utils_sayHello(a1, a2)
                         __stubs_globalAa = getGlobalAa()
@@ -283,7 +276,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     sub person_utils_sayHello(a1, a2)
                         __stubs_globalAa = getGlobalAa()
@@ -321,20 +314,22 @@ describe('MockUtil', () => {
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
                 let a = getContents('source/code.brs');
-                let b = trimLeading(`function __Person_builder()
-                instance = {}
-                instance.new = sub()
-                end sub
-                instance.sayHello = sub(a1, a2)
-                print "hello"
-                end sub
-                return instance
-                end function
-                function Person()
-                instance = __Person_builder()
-                instance.new()
-                return instance
-                end function`);
+                let b = undent(`
+                    function __Person_builder()
+                        instance = {}
+                        instance.new = sub()
+                        end sub
+                        instance.sayHello = sub(a1, a2)
+                            print "hello"
+                        end sub
+                        return instance
+                    end function
+                    function Person()
+                        instance = __Person_builder()
+                        instance.new()
+                        return instance
+                    end function
+                `);
                 expect(a).to.equal(b);
 
             });
@@ -357,7 +352,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     function __beings_Person_builder()
                         instance = {}
@@ -433,7 +428,7 @@ describe('MockUtil', () => {
                 program.validate();
                 expect(program.getDiagnostics()).to.be.empty;
                 await builder.transpile();
-                let a = getContents('source/code.brs', false);
+                let a = getContents('source/code.brs');
                 let b = undent(`
                     function beings_sayHello()
                         print "hello2"
@@ -453,14 +448,16 @@ describe('MockUtil', () => {
         });
 
         it('excludes files from coverage', async () => {
-            const source = `sub foo()
-        x = function(y)
-            if (true) then
-                return 1
-            end if
-            return 0
-        end function
-    end sub`;
+            const source = `
+                sub foo()
+                    x = function(y)
+                        if (true) then
+                            return 1
+                        end if
+                        return 0
+                    end function
+                end sub
+            `;
 
             program.setFile('source/code.coverageExcluded.bs', source);
             program.validate();
@@ -468,14 +465,16 @@ describe('MockUtil', () => {
             await builder.transpile();
 
             let a = getContents('source/code.coverageExcluded.brs');
-            let b = `sub foo()
-x = function(y)
-if (true) then
-return 1
-end if
-return 0
-end function
-end sub`;
+            let b = undent(`
+                sub foo()
+                    x = function(y)
+                        if (true) then
+                            return 1
+                        end if
+                        return 0
+                    end function
+                end sub
+            `);
 
             expect(a).to.equal(b);
         });

--- a/bsc-plugin/src/plugin.spec.ts
+++ b/bsc-plugin/src/plugin.spec.ts
@@ -2004,24 +2004,24 @@ describe('RooibosPlugin', () => {
             expect(findMethod('getIgnoredTestInfo').func.body.statements).to.be.empty;
 
             await builder.transpile();
-            let testContents = getTestFunctionContents(true);
+            let testContents = getTestFunctionContents();
             expect(
                 testContents
             ).to.eql(undent`
                 item = {
-                id: "item"
+                    id: "item"
                 }
                 m.currentAssertLineNumber = 7
                 m._expectNotCalled(item, "getFunction", item, "item")
                 if m.currentResult?.isFail = true then
-                m.done()
-                return invalid
+                    m.done()
+                    return invalid
                 end if
                 m.currentAssertLineNumber = 8
                 m._expectNotCalled(item, "getFunction", item, "item")
                 if m.currentResult?.isFail = true then
-                m.done()
-                return invalid
+                    m.done()
+                    return invalid
                 end if
             `);
 
@@ -2070,8 +2070,7 @@ describe('RooibosPlugin', () => {
                     instance.getIgnoredTestInfo = function()
                         return {
                             "count": 0
-                            "items": [
-                            ]
+                            "items": []
                         }
                     end function
                     return instance
@@ -2209,29 +2208,20 @@ function getContents(filename: string) {
     );
 }
 
-function getTestFunctionContents(trimEveryLine = false) {
+function getTestFunctionContents() {
     const contents = getContents('test.spec.brs');
 
     let [, result] = /instance.[\w_]+\s?\= function\(\)\s?([\S\s]*|.*)(?=^\s*end function\s+instance\.)/img.exec(contents);
 
-    if (trimEveryLine) {
-        result = trim(result);
-    }
     return undent(result);
 }
 
-function getTestSubContents(trimEveryLine = false) {
+function getTestSubContents() {
     const contents = getContents('test.spec.brs');
     const [, body] = /groupA_test1 \= sub\(\)([\S\s]*|.*)(?=end sub)/gim.exec(contents);
     let result = undent(
         body.split('end sub')[0]
     );
-    if (trimEveryLine) {
-        result = trim(result);
-    }
     return result;
 }
 
-function trimLeading(text: string) {
-    return text.split('\n').map((line) => line.trimStart()).join('\n');
-}


### PR DESCRIPTION
Requires #250 

Removes some usages of raw code statements fixing tons of oddities in tests related to indentation issues. Also cleans up a lot of the tests so that they are now all testing the saw way rather then some stripping all indentations and others not doing this. 