### PR TITLE
Code cov in if statements

### DIFF
--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -102,11 +102,13 @@ describe('RooibosPlugin', () => {
                             c++
                             RBS_CC_1_reportLine(7, 1)
                             c += 1
-                            if RBS_CC_1_reportLine(8, 3) and c = 2
+                            if RBS_CC_1_reportLine(8, 2) and (c = 2)
+                                RBS_CC_1_reportLine(8, 3)
                                 RBS_CC_1_reportLine(9, 1)
                                 ? "is true"
                             end if
-                            if RBS_CC_1_reportLine(12, 3) and c = 3
+                            if RBS_CC_1_reportLine(12, 2) and (c = 3)
+                                RBS_CC_1_reportLine(12, 3)
                                 RBS_CC_1_reportLine(13, 1)
                                 ? "free"
                             else
@@ -185,11 +187,13 @@ describe('RooibosPlugin', () => {
                             c++
                             RBS_CC_1_reportLine(7, 1)
                             c += 1
-                            if RBS_CC_1_reportLine(8, 3) and c = 2
+                            if RBS_CC_1_reportLine(8, 2) and (c = 2)
+                                RBS_CC_1_reportLine(8, 3)
                                 RBS_CC_1_reportLine(9, 1)
                                 ? "is true"
                             end if
-                            if RBS_CC_1_reportLine(12, 3) and c = 3
+                            if RBS_CC_1_reportLine(12, 2) and (c = 3)
+                                RBS_CC_1_reportLine(12, 3)
                                 RBS_CC_1_reportLine(13, 1)
                                 ? "free"
                             else
@@ -281,11 +285,13 @@ describe('RooibosPlugin', () => {
                             c++
                             RBS_CC_1_reportLine(11, 1)
                             c += 1
-                            if RBS_CC_1_reportLine(12, 3) and c = 2
+                            if RBS_CC_1_reportLine(12, 2) and (c = 2)
+                                RBS_CC_1_reportLine(12, 3)
                                 RBS_CC_1_reportLine(13, 1)
                                 ? "is true"
                             end if
-                            if RBS_CC_1_reportLine(16, 3) and c = 3
+                            if RBS_CC_1_reportLine(16, 2) and (c = 3)
+                                RBS_CC_1_reportLine(16, 3)
                                 RBS_CC_1_reportLine(17, 1)
                                 ? "free"
                             else
@@ -350,7 +356,8 @@ describe('RooibosPlugin', () => {
                     sub foo()
                         RBS_CC_1_reportLine(1, 1)
                         x = function(y)
-                            if RBS_CC_1_reportLine(2, 3) and (true) then
+                            if RBS_CC_1_reportLine(2, 2) and ((true)) then
+                                RBS_CC_1_reportLine(2, 3)
                                 RBS_CC_1_reportLine(3, 1)
                                 return 1
                             end if
@@ -397,7 +404,6 @@ describe('RooibosPlugin', () => {
                         else if action = "action3" then
                             print "action3"
                         else if action = "action4" then
-                            print "action4"
                         else if action = "action5" then
                             print "action5"
                         else if action = "action6" then
@@ -410,6 +416,7 @@ describe('RooibosPlugin', () => {
                             print "action9"
                         else if action = "action10" then
                             print "action10"
+                        else
                         end if
                     end sub
                 `;
@@ -422,36 +429,46 @@ describe('RooibosPlugin', () => {
                 let a = getContents('source/code.brs');
                 let b = undent(`
                     sub foo(action as string)
-                        if RBS_CC_1_reportLine(2, 3) and action = "action1" then
+                        if RBS_CC_1_reportLine(2, 2) and (action = "action1") then
+                            RBS_CC_1_reportLine(2, 3)
                             RBS_CC_1_reportLine(3, 1)
                             print "action1"
-                        else if (RBS_CC_1_reportLine(4, 3) and action = "action2") or (RBS_CC_1_reportLine(4, 3) and action = "action2") then
+                        else if RBS_CC_1_reportLine(4, 2) and (action = "action2" or action = "action2") then
+                            RBS_CC_1_reportLine(4, 3)
                             RBS_CC_1_reportLine(5, 1)
                             print "action2"
-                        else if RBS_CC_1_reportLine(6, 3) and action = "action3" then
+                        else if RBS_CC_1_reportLine(6, 2) and (action = "action3") then
+                            RBS_CC_1_reportLine(6, 3)
                             RBS_CC_1_reportLine(7, 1)
                             print "action3"
-                        else if RBS_CC_1_reportLine(8, 3) and action = "action4" then
-                            RBS_CC_1_reportLine(9, 1)
-                            print "action4"
-                        else if RBS_CC_1_reportLine(10, 3) and action = "action5" then
-                            RBS_CC_1_reportLine(11, 1)
+                        else if RBS_CC_1_reportLine(8, 2) and (action = "action4") then
+                            RBS_CC_1_reportLine(8, 3)
+                        else if RBS_CC_1_reportLine(9, 2) and (action = "action5") then
+                            RBS_CC_1_reportLine(9, 3)
+                            RBS_CC_1_reportLine(10, 1)
                             print "action5"
-                        else if RBS_CC_1_reportLine(12, 3) and action = "action6" then
-                            RBS_CC_1_reportLine(13, 1)
+                        else if RBS_CC_1_reportLine(11, 2) and (action = "action6") then
+                            RBS_CC_1_reportLine(11, 3)
+                            RBS_CC_1_reportLine(12, 1)
                             print "action6"
-                        else if RBS_CC_1_reportLine(14, 3) and action = "action7" then
-                            RBS_CC_1_reportLine(15, 1)
+                        else if RBS_CC_1_reportLine(13, 2) and (action = "action7") then
+                            RBS_CC_1_reportLine(13, 3)
+                            RBS_CC_1_reportLine(14, 1)
                             print "action7"
-                        else if RBS_CC_1_reportLine(16, 3) and action = "action8" then
-                            RBS_CC_1_reportLine(17, 1)
+                        else if RBS_CC_1_reportLine(15, 2) and (action = "action8") then
+                            RBS_CC_1_reportLine(15, 3)
+                            RBS_CC_1_reportLine(16, 1)
                             print "action8"
-                        else if RBS_CC_1_reportLine(18, 3) and action = "action9" then
-                            RBS_CC_1_reportLine(19, 1)
+                        else if RBS_CC_1_reportLine(17, 2) and (action = "action9") then
+                            RBS_CC_1_reportLine(17, 3)
+                            RBS_CC_1_reportLine(18, 1)
                             print "action9"
-                        else if RBS_CC_1_reportLine(20, 3) and action = "action10" then
-                            RBS_CC_1_reportLine(21, 1)
+                        else if RBS_CC_1_reportLine(19, 2) and (action = "action10") then
+                            RBS_CC_1_reportLine(19, 3)
+                            RBS_CC_1_reportLine(20, 1)
                             print "action10"
+                        else
+                            RBS_CC_1_reportLine(21, 3)
                         end if
                     end sub
 

--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -91,55 +91,54 @@ describe('RooibosPlugin', () => {
                 let a = getContents('source/code.brs');
                 let b = undent(`
                     function new(a1, a2)
-                        RBS_CC_1_reportLine(2, 1)
+                        RBS_CC_1_reportLine("2", 1)
                         c = 0
-                        RBS_CC_1_reportLine(3, 1)
+                        RBS_CC_1_reportLine("3", 1)
                         text = ""
-                        RBS_CC_1_reportLine(4, 1): for i = 0 to 10
-                            RBS_CC_1_reportLine(5, 1)
+                        RBS_CC_1_reportLine("4", 1): for i = 0 to 10
+                            RBS_CC_1_reportLine("5", 1)
                             text = text + "hello"
-                            RBS_CC_1_reportLine(6, 1)
+                            RBS_CC_1_reportLine("6", 1)
                             c++
-                            RBS_CC_1_reportLine(7, 1)
+                            RBS_CC_1_reportLine("7", 1)
                             c += 1
-                            if RBS_CC_1_reportLine(8, 2) and (c = 2)
-                                RBS_CC_1_reportLine(8, 3)
-                                RBS_CC_1_reportLine(9, 1)
+                            if RBS_CC_1_reportLine("8", 2) and (c = 2)
+                                RBS_CC_1_reportLine("8", 3)
+                                RBS_CC_1_reportLine("9", 1)
                                 ? "is true"
                             end if
-                            if RBS_CC_1_reportLine(12, 2) and (c = 3)
-                                RBS_CC_1_reportLine(12, 3)
-                                RBS_CC_1_reportLine(13, 1)
+                            if RBS_CC_1_reportLine("12", 2) and (c = 3)
+                                RBS_CC_1_reportLine("12", 3)
+                                RBS_CC_1_reportLine("13", 1)
                                 ? "free"
                             else
-                                RBS_CC_1_reportLine(14, 3)
-                                RBS_CC_1_reportLine(15, 1)
+                                RBS_CC_1_reportLine("14", 3)
+                                RBS_CC_1_reportLine("15", 1)
                                 ? "not free"
                             end if
                         end for
                     end function
 
                     function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        if m.global = invalid
-                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                        _rbs_ccn = m._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
                             return true
-                        else
-                            if m._rbs_ccn = invalid
-                                '? "Coverage maps are not created - creating now"
-                                if m.global._rbs_ccn = invalid
-                                    '? "Coverage maps are not created - creating now"
-                                    m.global.addFields({
-                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-                                    })
-                                end if
-                                m._rbs_ccn = m.global._rbs_ccn
-                            end if
                         end if
-                        m._rbs_ccn.entry = {
-                            "f": "1"
-                            "l": stri(lineNumber)
-                            "r": reportType
-                        }
+                        _rbs_ccn = m?.global?._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
+                            m._rbs_ccn = _rbs_ccn
+                            return true
+                        end if
                         return true
                     end function
                 `);
@@ -176,55 +175,54 @@ describe('RooibosPlugin', () => {
                 let a = getContents('source/code.brs');
                 let b = undent(`
                     function new(a1, a2)
-                        RBS_CC_1_reportLine(2, 1)
+                        RBS_CC_1_reportLine("2", 1)
                         c = 0
-                        RBS_CC_1_reportLine(3, 1)
+                        RBS_CC_1_reportLine("3", 1)
                         text = ""
-                        RBS_CC_1_reportLine(4, 1): for i = 0 to 10
-                            RBS_CC_1_reportLine(5, 1)
+                        RBS_CC_1_reportLine("4", 1): for i = 0 to 10
+                            RBS_CC_1_reportLine("5", 1)
                             text = text + "hello"
-                            RBS_CC_1_reportLine(6, 1)
+                            RBS_CC_1_reportLine("6", 1)
                             c++
-                            RBS_CC_1_reportLine(7, 1)
+                            RBS_CC_1_reportLine("7", 1)
                             c += 1
-                            if RBS_CC_1_reportLine(8, 2) and (c = 2)
-                                RBS_CC_1_reportLine(8, 3)
-                                RBS_CC_1_reportLine(9, 1)
+                            if RBS_CC_1_reportLine("8", 2) and (c = 2)
+                                RBS_CC_1_reportLine("8", 3)
+                                RBS_CC_1_reportLine("9", 1)
                                 ? "is true"
                             end if
-                            if RBS_CC_1_reportLine(12, 2) and (c = 3)
-                                RBS_CC_1_reportLine(12, 3)
-                                RBS_CC_1_reportLine(13, 1)
+                            if RBS_CC_1_reportLine("12", 2) and (c = 3)
+                                RBS_CC_1_reportLine("12", 3)
+                                RBS_CC_1_reportLine("13", 1)
                                 ? "free"
                             else
-                                RBS_CC_1_reportLine(14, 3)
-                                RBS_CC_1_reportLine(15, 1)
+                                RBS_CC_1_reportLine("14", 3)
+                                RBS_CC_1_reportLine("15", 1)
                                 ? "not free"
                             end if
                         end for
                     end function
 
                     function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        if m.global = invalid
-                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                        _rbs_ccn = m._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
                             return true
-                        else
-                            if m._rbs_ccn = invalid
-                                '? "Coverage maps are not created - creating now"
-                                if m.global._rbs_ccn = invalid
-                                    '? "Coverage maps are not created - creating now"
-                                    m.global.addFields({
-                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-                                    })
-                                end if
-                                m._rbs_ccn = m.global._rbs_ccn
-                            end if
                         end if
-                        m._rbs_ccn.entry = {
-                            "f": "1"
-                            "l": stri(lineNumber)
-                            "r": reportType
-                        }
+                        _rbs_ccn = m?.global?._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
+                            m._rbs_ccn = _rbs_ccn
+                            return true
+                        end if
                         return true
                     end function
                 `);
@@ -274,29 +272,29 @@ describe('RooibosPlugin', () => {
                     instance.new = function(a1, a2)
                         m.field1 = invalid
                         m.field2 = invalid
-                        RBS_CC_1_reportLine(6, 1)
+                        RBS_CC_1_reportLine("6", 1)
                         c = 0
-                        RBS_CC_1_reportLine(7, 1)
+                        RBS_CC_1_reportLine("7", 1)
                         text = ""
-                        RBS_CC_1_reportLine(8, 1): for i = 0 to 10
-                            RBS_CC_1_reportLine(9, 1)
+                        RBS_CC_1_reportLine("8", 1): for i = 0 to 10
+                            RBS_CC_1_reportLine("9", 1)
                             text = text + "hello"
-                            RBS_CC_1_reportLine(10, 1)
+                            RBS_CC_1_reportLine("10", 1)
                             c++
-                            RBS_CC_1_reportLine(11, 1)
+                            RBS_CC_1_reportLine("11", 1)
                             c += 1
-                            if RBS_CC_1_reportLine(12, 2) and (c = 2)
-                                RBS_CC_1_reportLine(12, 3)
-                                RBS_CC_1_reportLine(13, 1)
+                            if RBS_CC_1_reportLine("12", 2) and (c = 2)
+                                RBS_CC_1_reportLine("12", 3)
+                                RBS_CC_1_reportLine("13", 1)
                                 ? "is true"
                             end if
-                            if RBS_CC_1_reportLine(16, 2) and (c = 3)
-                                RBS_CC_1_reportLine(16, 3)
-                                RBS_CC_1_reportLine(17, 1)
+                            if RBS_CC_1_reportLine("16", 2) and (c = 3)
+                                RBS_CC_1_reportLine("16", 3)
+                                RBS_CC_1_reportLine("17", 1)
                                 ? "free"
                             else
-                                RBS_CC_1_reportLine(18, 3)
-                                RBS_CC_1_reportLine(19, 1)
+                                RBS_CC_1_reportLine("18", 3)
+                                RBS_CC_1_reportLine("19", 1)
                                 ? "not free"
                             end if
                         end for
@@ -310,26 +308,25 @@ describe('RooibosPlugin', () => {
                 end function
 
                 function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                    if m.global = invalid
-                        '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                    _rbs_ccn = m._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
                         return true
-                    else
-                        if m._rbs_ccn = invalid
-                            '? "Coverage maps are not created - creating now"
-                            if m.global._rbs_ccn = invalid
-                                '? "Coverage maps are not created - creating now"
-                                m.global.addFields({
-                                    "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-                                })
-                            end if
-                            m._rbs_ccn = m.global._rbs_ccn
-                        end if
                     end if
-                    m._rbs_ccn.entry = {
-                        "f": "1"
-                        "l": stri(lineNumber)
-                        "r": reportType
-                    }
+                    _rbs_ccn = m?.global?._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        m._rbs_ccn = _rbs_ccn
+                        return true
+                    end if
                     return true
                 end function
                 `);
@@ -354,39 +351,38 @@ describe('RooibosPlugin', () => {
                 let a = getContents('source/code.brs');
                 let b = undent(`
                     sub foo()
-                        RBS_CC_1_reportLine(1, 1)
+                        RBS_CC_1_reportLine("1", 1)
                         x = function(y)
-                            if RBS_CC_1_reportLine(2, 2) and ((true)) then
-                                RBS_CC_1_reportLine(2, 3)
-                                RBS_CC_1_reportLine(3, 1)
+                            if RBS_CC_1_reportLine("2", 2) and ((true)) then
+                                RBS_CC_1_reportLine("2", 3)
+                                RBS_CC_1_reportLine("3", 1)
                                 return 1
                             end if
-                            RBS_CC_1_reportLine(5, 1)
+                            RBS_CC_1_reportLine("5", 1)
                             return 0
                         end function
                     end sub
 
                     function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        if m.global = invalid
-                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                        _rbs_ccn = m._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
                             return true
-                        else
-                            if m._rbs_ccn = invalid
-                                '? "Coverage maps are not created - creating now"
-                                if m.global._rbs_ccn = invalid
-                                    '? "Coverage maps are not created - creating now"
-                                    m.global.addFields({
-                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-                                    })
-                                end if
-                                m._rbs_ccn = m.global._rbs_ccn
-                            end if
                         end if
-                        m._rbs_ccn.entry = {
-                            "f": "1"
-                            "l": stri(lineNumber)
-                            "r": reportType
-                        }
+                        _rbs_ccn = m?.global?._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
+                            m._rbs_ccn = _rbs_ccn
+                            return true
+                        end if
                         return true
                     end function
                 `);
@@ -429,70 +425,69 @@ describe('RooibosPlugin', () => {
                 let a = getContents('source/code.brs');
                 let b = undent(`
                     sub foo(action as string)
-                        if RBS_CC_1_reportLine(2, 2) and (action = "action1") then
-                            RBS_CC_1_reportLine(2, 3)
-                            RBS_CC_1_reportLine(3, 1)
+                        if RBS_CC_1_reportLine("2", 2) and (action = "action1") then
+                            RBS_CC_1_reportLine("2", 3)
+                            RBS_CC_1_reportLine("3", 1)
                             print "action1"
-                        else if RBS_CC_1_reportLine(4, 2) and (action = "action2" or action = "action2") then
-                            RBS_CC_1_reportLine(4, 3)
-                            RBS_CC_1_reportLine(5, 1)
+                        else if RBS_CC_1_reportLine("4", 2) and (action = "action2" or action = "action2") then
+                            RBS_CC_1_reportLine("4", 3)
+                            RBS_CC_1_reportLine("5", 1)
                             print "action2"
-                        else if RBS_CC_1_reportLine(6, 2) and (action = "action3") then
-                            RBS_CC_1_reportLine(6, 3)
-                            RBS_CC_1_reportLine(7, 1)
+                        else if RBS_CC_1_reportLine("6", 2) and (action = "action3") then
+                            RBS_CC_1_reportLine("6", 3)
+                            RBS_CC_1_reportLine("7", 1)
                             print "action3"
-                        else if RBS_CC_1_reportLine(8, 2) and (action = "action4") then
-                            RBS_CC_1_reportLine(8, 3)
-                        else if RBS_CC_1_reportLine(9, 2) and (action = "action5") then
-                            RBS_CC_1_reportLine(9, 3)
-                            RBS_CC_1_reportLine(10, 1)
+                        else if RBS_CC_1_reportLine("8", 2) and (action = "action4") then
+                            RBS_CC_1_reportLine("8", 3)
+                        else if RBS_CC_1_reportLine("9", 2) and (action = "action5") then
+                            RBS_CC_1_reportLine("9", 3)
+                            RBS_CC_1_reportLine("10", 1)
                             print "action5"
-                        else if RBS_CC_1_reportLine(11, 2) and (action = "action6") then
-                            RBS_CC_1_reportLine(11, 3)
-                            RBS_CC_1_reportLine(12, 1)
+                        else if RBS_CC_1_reportLine("11", 2) and (action = "action6") then
+                            RBS_CC_1_reportLine("11", 3)
+                            RBS_CC_1_reportLine("12", 1)
                             print "action6"
-                        else if RBS_CC_1_reportLine(13, 2) and (action = "action7") then
-                            RBS_CC_1_reportLine(13, 3)
-                            RBS_CC_1_reportLine(14, 1)
+                        else if RBS_CC_1_reportLine("13", 2) and (action = "action7") then
+                            RBS_CC_1_reportLine("13", 3)
+                            RBS_CC_1_reportLine("14", 1)
                             print "action7"
-                        else if RBS_CC_1_reportLine(15, 2) and (action = "action8") then
-                            RBS_CC_1_reportLine(15, 3)
-                            RBS_CC_1_reportLine(16, 1)
+                        else if RBS_CC_1_reportLine("15", 2) and (action = "action8") then
+                            RBS_CC_1_reportLine("15", 3)
+                            RBS_CC_1_reportLine("16", 1)
                             print "action8"
-                        else if RBS_CC_1_reportLine(17, 2) and (action = "action9") then
-                            RBS_CC_1_reportLine(17, 3)
-                            RBS_CC_1_reportLine(18, 1)
+                        else if RBS_CC_1_reportLine("17", 2) and (action = "action9") then
+                            RBS_CC_1_reportLine("17", 3)
+                            RBS_CC_1_reportLine("18", 1)
                             print "action9"
-                        else if RBS_CC_1_reportLine(19, 2) and (action = "action10") then
-                            RBS_CC_1_reportLine(19, 3)
-                            RBS_CC_1_reportLine(20, 1)
+                        else if RBS_CC_1_reportLine("19", 2) and (action = "action10") then
+                            RBS_CC_1_reportLine("19", 3)
+                            RBS_CC_1_reportLine("20", 1)
                             print "action10"
                         else
-                            RBS_CC_1_reportLine(21, 3)
+                            RBS_CC_1_reportLine("21", 3)
                         end if
                     end sub
 
                     function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        if m.global = invalid
-                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                        _rbs_ccn = m._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
                             return true
-                        else
-                            if m._rbs_ccn = invalid
-                                '? "Coverage maps are not created - creating now"
-                                if m.global._rbs_ccn = invalid
-                                    '? "Coverage maps are not created - creating now"
-                                    m.global.addFields({
-                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-                                    })
-                                end if
-                                m._rbs_ccn = m.global._rbs_ccn
-                            end if
                         end if
-                        m._rbs_ccn.entry = {
-                            "f": "1"
-                            "l": stri(lineNumber)
-                            "r": reportType
-                        }
+                        _rbs_ccn = m?.global?._rbs_ccn
+                        if _rbs_ccn <> invalid
+                            _rbs_ccn.entry = {
+                                "f": "1"
+                                "l": lineNumber
+                                "r": reportType
+                            }
+                            m._rbs_ccn = _rbs_ccn
+                            return true
+                        end if
                         return true
                     end function
                 `);

--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -386,6 +386,102 @@ describe('RooibosPlugin', () => {
 
                 expect(a).to.equal(b);
             });
+
+            it('correctly transpiles some statements', async () => {
+                const source = `
+                    sub foo(action as string)
+                        if action = "action1" then
+                            print "action1"
+                        else if action = "action2" or action = "action2" then
+                            print "action2"
+                        else if action = "action3" then
+                            print "action3"
+                        else if action = "action4" then
+                            print "action4"
+                        else if action = "action5" then
+                            print "action5"
+                        else if action = "action6" then
+                            print "action6"
+                        else if action = "action7" then
+                            print "action7"
+                        else if action = "action8" then
+                            print "action8"
+                        else if action = "action9" then
+                            print "action9"
+                        else if action = "action10" then
+                            print "action10"
+                        end if
+                    end sub
+                `;
+
+                program.setFile('source/code.bs', source);
+                program.validate();
+                expect(program.getDiagnostics()).to.be.empty;
+                await builder.transpile();
+
+                let a = getContents('source/code.brs');
+                let b = undent(`
+                    sub foo(action as string)
+                        if RBS_CC_1_reportLine(2, 3) and action = "action1" then
+                            RBS_CC_1_reportLine(3, 1)
+                            print "action1"
+                        else if (RBS_CC_1_reportLine(4, 3) and action = "action2") or (RBS_CC_1_reportLine(4, 3) and action = "action2") then
+                            RBS_CC_1_reportLine(5, 1)
+                            print "action2"
+                        else if RBS_CC_1_reportLine(6, 3) and action = "action3" then
+                            RBS_CC_1_reportLine(7, 1)
+                            print "action3"
+                        else if RBS_CC_1_reportLine(8, 3) and action = "action4" then
+                            RBS_CC_1_reportLine(9, 1)
+                            print "action4"
+                        else if RBS_CC_1_reportLine(10, 3) and action = "action5" then
+                            RBS_CC_1_reportLine(11, 1)
+                            print "action5"
+                        else if RBS_CC_1_reportLine(12, 3) and action = "action6" then
+                            RBS_CC_1_reportLine(13, 1)
+                            print "action6"
+                        else if RBS_CC_1_reportLine(14, 3) and action = "action7" then
+                            RBS_CC_1_reportLine(15, 1)
+                            print "action7"
+                        else if RBS_CC_1_reportLine(16, 3) and action = "action8" then
+                            RBS_CC_1_reportLine(17, 1)
+                            print "action8"
+                        else if RBS_CC_1_reportLine(18, 3) and action = "action9" then
+                            RBS_CC_1_reportLine(19, 1)
+                            print "action9"
+                        else if RBS_CC_1_reportLine(20, 3) and action = "action10" then
+                            RBS_CC_1_reportLine(21, 1)
+                            print "action10"
+                        end if
+                    end sub
+
+                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                        if m.global = invalid
+                            '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                            return true
+                        else
+                            if m._rbs_ccn = invalid
+                                '? "Coverage maps are not created - creating now"
+                                if m.global._rbs_ccn = invalid
+                                    '? "Coverage maps are not created - creating now"
+                                    m.global.addFields({
+                                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
+                                    })
+                                end if
+                                m._rbs_ccn = m.global._rbs_ccn
+                            end if
+                        end if
+                        m._rbs_ccn.entry = {
+                            "f": "1"
+                            "l": stri(lineNumber)
+                            "r": reportType
+                        }
+                        return true
+                    end function
+                `);
+
+                expect(a).to.equal(b);
+            });
         });
 
         it('excludes files from coverage', async () => {

--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
@@ -19,23 +19,25 @@ export class CodeCoverageProcessor {
 
     private coverageBrsTemplate = `
         function RBS_CC_#ID#_reportLine(lineNumber, reportType = 1)
-            if m.global = invalid
-                '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
-                return true
-            else
-                if m._rbs_ccn = invalid
-                '? "Coverage maps are not created - creating now"
-                if m.global._rbs_ccn = invalid
-                    '? "Coverage maps are not created - creating now"
-                    m.global.addFields({
-                        "_rbs_ccn": createObject("roSGNode", "CodeCoverage")
-                    })
+            _rbs_ccn = m._rbs_ccn
+            if _rbs_ccn = invalid
+                _rbs_ccn = m?.global?._rbs_ccn
+                if _rbs_ccn = invalid
+                    if m.global = invalid
+                        '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
+                        return true
+                    else
+                        '? "Coverage maps are not created - creating now"
+                        _rbs_ccn = createObject("roSGNode", "CodeCoverage")
+                        m.global.update({
+                            "_rbs_ccn": _rbs_ccn
+                        }, true)
+                    end if
                 end if
-                m._rbs_ccn = m.global._rbs_ccn
-                end if
+                m._rbs_ccn = _rbs_ccn
             end if
 
-            m._rbs_ccn.entry = {"f":"#ID#", "l":stri(lineNumber), "r":reportType}
+            _rbs_ccn.entry = { "f": "#ID#", "l": lineNumber, "r": reportType }
             return true
         end function
     `;
@@ -195,6 +197,6 @@ export class CodeCoverageProcessor {
     }
 
     private getFuncCallText(lineNumber: number, lineType: CodeCoverageLineType) {
-        return `RBS_CC_${this.fileId}_reportLine(${lineNumber.toString().trim()}, ${lineType.toString().trim()})`;
+        return `RBS_CC_${this.fileId}_reportLine("${lineNumber.toString().trim()}", ${lineType.toString().trim()})`;
     }
 }

--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { BrsFile, Editor, ExpressionStatement, Program, ProgramBuilder, Statement } from 'brighterscript';
-import { Parser, isIfStatement, WalkMode, createVisitor } from 'brighterscript';
-import * as brighterscript from 'brighterscript';
+import { Parser, WalkMode, createVisitor, BinaryExpression, createToken, TokenKind, GroupingExpression, isForStatement, isBlock } from 'brighterscript';
 import type { RooibosConfig } from './RooibosConfig';
 import { RawCodeStatement } from './RawCodeStatement';
 import { BrsTranspileState } from 'brighterscript/dist/parser/BrsTranspileState';
@@ -89,20 +88,30 @@ export class CodeCoverageProcessor {
                 this.addStatement(ds);
                 ds.forToken.text = `${this.getFuncCallText(ds.range.start.line, CodeCoverageLineType.code)}: for`;
             },
-            IfStatement: (ds, parent, owner, key) => {
-                let ifStatement = ds;
-                while (isIfStatement(ifStatement)) {
-                    this.addStatement(ds);
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    (ifStatement as any).condition = new brighterscript.BinaryExpression(new RawCodeExpression(this.getFuncCallText(ds.condition.range.start.line, CodeCoverageLineType.branch)), brighterscript.createToken(brighterscript.TokenKind.And), (ifStatement as any).condition);
-                    ifStatement = ifStatement.elseBranch as any;
-                }
-                let blockStatements = (ifStatement as any)?.statements as any[] ?? [];
-                if (blockStatements?.length > 0) {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    let coverageStatement = new RawCodeStatement(this.getFuncCallText((ifStatement as any).range.start.line - 1, CodeCoverageLineType.branch));
+            IfStatement: (ifStatement, parent, owner, key) => {
+                this.addStatement(ifStatement);
+                (ifStatement as any).condition = new BinaryExpression(
+                    new RawCodeExpression(this.getFuncCallText(ifStatement.condition.range.start.line, CodeCoverageLineType.condition)),
+                    createToken(TokenKind.And),
+                    new GroupingExpression({
+                        left: createToken(TokenKind.LeftParen),
+                        right: createToken(TokenKind.RightParen)
+                    }, ifStatement.condition)
+                );
+
+                let blockStatements = ifStatement?.thenBranch?.statements;
+                if (blockStatements) {
+                    let coverageStatement = new RawCodeStatement(this.getFuncCallText(ifStatement.range.start.line, CodeCoverageLineType.branch));
                     blockStatements.splice(0, 0, coverageStatement);
                 }
+
+                // Handle the else blocks
+                let elseBlock = ifStatement.elseBranch;
+                if (isBlock(elseBlock) && elseBlock.statements) {
+                    let coverageStatement = new RawCodeStatement(this.getFuncCallText(elseBlock.range.start.line - 1, CodeCoverageLineType.branch));
+                    elseBlock.statements.splice(0, 0, coverageStatement);
+                }
+
             },
             GotoStatement: (ds, parent, owner, key) => {
                 this.addStatement(ds);
@@ -143,7 +152,7 @@ export class CodeCoverageProcessor {
 
             },
             AssignmentStatement: (ds, parent, owner, key) => {
-                if (!brighterscript.isForStatement(parent)) {
+                if (!isForStatement(parent)) {
                     this.addStatement(ds);
                     this.convertStatementToCoverageStatement(ds, CodeCoverageLineType.code, owner, key);
                 }

--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
@@ -20,24 +20,17 @@ export class CodeCoverageProcessor {
     private coverageBrsTemplate = `
         function RBS_CC_#ID#_reportLine(lineNumber, reportType = 1)
             _rbs_ccn = m._rbs_ccn
-            if _rbs_ccn = invalid
-                _rbs_ccn = m?.global?._rbs_ccn
-                if _rbs_ccn = invalid
-                    if m.global = invalid
-                        '? "global is not available in this scope!! it is not possible to record coverage: #FILE_PATH#(lineNumber)"
-                        return true
-                    else
-                        '? "Coverage maps are not created - creating now"
-                        _rbs_ccn = createObject("roSGNode", "CodeCoverage")
-                        m.global.update({
-                            "_rbs_ccn": _rbs_ccn
-                        }, true)
-                    end if
-                end if
-                m._rbs_ccn = _rbs_ccn
+            if _rbs_ccn <> invalid
+                _rbs_ccn.entry = { "f": "#ID#", "l": lineNumber, "r": reportType }
+                return true
             end if
 
-            _rbs_ccn.entry = { "f": "#ID#", "l": lineNumber, "r": reportType }
+            _rbs_ccn = m?.global?._rbs_ccn
+            if _rbs_ccn <> invalid
+                _rbs_ccn.entry = { "f": "#ID#", "l": lineNumber, "r": reportType }
+                m._rbs_ccn = _rbs_ccn
+                return true
+            end if
             return true
         end function
     `;
@@ -66,9 +59,7 @@ export class CodeCoverageProcessor {
     private astEditor: Editor;
 
     public generateMetadata(isUsingCoverage: boolean, program: Program) {
-        if (isUsingCoverage) {
-            this.fileFactory.createCoverageComponent(program, this.expectedCoverageMap, this.filePathMap);
-        }
+        this.fileFactory.createCoverageComponent(program, this.expectedCoverageMap, this.filePathMap);
     }
 
     public addCodeCoverage(file: BrsFile, astEditor: Editor) {

--- a/framework/src/source/CodeCoverage.brs
+++ b/framework/src/source/CodeCoverage.brs
@@ -2,7 +2,7 @@ function init()
   m.resolvedMap = {}
   m.top.observeField("entry", "onEntryChange")
   m.top.observeField("save", "onSave")
-
+  m.results = []
 end function
 
 function setExpectedMap()
@@ -15,19 +15,24 @@ end function
 
 function onEntryChange()
 entry = m.top.entry
-  if entry <> invalid
-    lineMap = m.resolvedMap[entry.f]
-
-    if lineMap = invalid
-      lineMap = {}
-      m.resolvedMap[entry.f] = lineMap
-    end if
-    lineMap[entry.l] = entry.r
-  end if
+  ' defer till later
+  m.results.push(entry)
 end function
 
 function onSave()
   ? "saving data"
+  for each entry in m.results
+    if entry <> invalid
+      fileId = entry.f
+      lineMap = m.resolvedMap[fileId]
+
+      if lineMap = invalid
+        lineMap = {}
+        m.resolvedMap[fileId] = lineMap
+      end if
+      lineMap[entry.l] = entry.r
+    end if
+  end for
   m.top.resolvedMap = m.resolvedMap
   setExpectedMap()
   setFilePathMap()

--- a/framework/src/source/CodeCoverage.brs
+++ b/framework/src/source/CodeCoverage.brs
@@ -20,10 +20,9 @@ entry = m.top.entry
 
     if lineMap = invalid
       lineMap = {}
+      m.resolvedMap[entry.f] = lineMap
     end if
     lineMap[entry.l] = entry.r
-
-    m.resolvedMap[entry.f] = lineMap
   end if
 end function
 

--- a/framework/src/source/Coverage.bs
+++ b/framework/src/source/Coverage.bs
@@ -5,25 +5,32 @@ namespace rooibos.Coverage
       ? "There was no rooibos code coverage component - not generating coverage report"
       return
     end if
+    t = createObject("roTimespan")
     ? ""
     ? "...Generating code coverage report"
     ? ""
     m.global._rbs_ccn.save = true
     cc = m.global._rbs_ccn
+    expectedMap = cc.expectedMap
+    filePathMap = cc.filePathMap
+    resolvedMap = cc.resolvedMap
+
     hitFiles = []
     missFiles = []
     allLinesCount = 0
     allLinesHit = 0
-    for each key in cc.expectedMap
-      filename = cc.filePathMap[key]
-      expectedCount = cc.expectedMap[key].count()
+    for each key in expectedMap
+      filename = filePathMap[key]
+      expectedCount = expectedMap[key].count()
       allLinesCount += expectedCount
       if expectedCount > 0
-        if cc.resolvedMap[key] <> invalid
-          resolvedCount = cc.resolvedMap[key].count()
+        if resolvedMap[key] <> invalid
+          resolvedCount = resolvedMap[key].count()
           allLinesHit += resolvedCount
           resolvedPercent = (resolvedCount / expectedCount) * 100
           hitFiles.push({ percent: resolvedPercent, text: filename + ": " + str(resolvedPercent).trim() + "% (" + stri(resolvedCount).trim() + "/" + stri(expectedCount).trim() + ")" })
+        else
+          missFiles.push(filename + ": MISS!")
         end if
       else
         missFiles.push(filename + ": MISS!")
@@ -37,7 +44,7 @@ namespace rooibos.Coverage
     ? "+++++++++++++++++++++++++++++++++++++++++++"
     ? ""
     ? "Total Coverage: " ; str(allLinesPercent).trim() ; "% (" ; stri(allLinesHit).trim() ; "/" + stri(allLinesCount).trim() ; ")"
-    ? "Files: " ; cc.resolvedMap.count(); "/" ; cc.expectedMap.count()
+    ? "Files: " ; resolvedMap.count(); "/" ; expectedMap.count()
     ? ""
     ? "HIT FILES"
     ? "---------"
@@ -51,7 +58,10 @@ namespace rooibos.Coverage
     for i = 0 to missFiles.count() - 1
       ? missFiles[i]
     end for
-
+    ? ""
+    ? "+++++++++++++++++++++++++++++++++++++++++++"
+    ? "Code Coverage Report Complete"; t.totalMilliseconds(); "ms"
+    ? "+++++++++++++++++++++++++++++++++++++++++++"
   end function
 
   function createLCovOutput()

--- a/framework/src/source/Coverage.bs
+++ b/framework/src/source/Coverage.bs
@@ -27,7 +27,11 @@ namespace rooibos.Coverage
         if resolvedMap[key] <> invalid
           resolvedCount = resolvedMap[key].count()
           allLinesHit += resolvedCount
-          resolvedPercent = (resolvedCount / expectedCount) * 100
+          if resolvedCount = 0
+            resolvedPercent = 0
+          else
+            resolvedPercent = (resolvedCount / expectedCount) * 100
+          end if
           hitFiles.push({ percent: resolvedPercent, text: filename + ": " + str(resolvedPercent).trim() + "% (" + stri(resolvedCount).trim() + "/" + stri(expectedCount).trim() + ")" })
         else
           missFiles.push(filename + ": MISS!")
@@ -36,7 +40,11 @@ namespace rooibos.Coverage
         missFiles.push(filename + ": MISS!")
       end if
     end for
-    allLinesPercent = (allLinesHit / allLinesCount) * 100
+    if allLinesHit = 0
+      allLinesPercent = 0
+    else
+      allLinesPercent = (allLinesHit / allLinesCount) * 100
+    end if
     ? ""
     ? ""
     ? "+++++++++++++++++++++++++++++++++++++++++++"

--- a/framework/src/source/Coverage.bs
+++ b/framework/src/source/Coverage.bs
@@ -24,9 +24,9 @@ namespace rooibos.Coverage
           allLinesHit += resolvedCount
           resolvedPercent = (resolvedCount / expectedCount) * 100
           hitFiles.push({ percent: resolvedPercent, text: filename + ": " + str(resolvedPercent).trim() + "% (" + stri(resolvedCount).trim() + "/" + stri(expectedCount).trim() + ")" })
-        else
-          missFiles.push(filename + ": MISS!")
         end if
+      else
+        missFiles.push(filename + ": MISS!")
       end if
     end for
     allLinesPercent = (allLinesHit / allLinesCount) * 100

--- a/framework/src/source/Rooibos.bs
+++ b/framework/src/source/Rooibos.bs
@@ -18,7 +18,10 @@ namespace rooibos
     screen.show()
 
     m.global = screen.getGlobalNode()
-    m.global.addFields({ "testsScene": scene })
+    m.global.addFields({
+      "testsScene": scene
+      "_rbs_ccn": createObject("roSGNode", "CodeCoverage")' bs:disable-line
+    })
 
     if scene.hasField("isReadyToStartTests") and scene.isReadyToStartTests = false
       ? "The scene is not ready yet - waiting for it to set isReadyToStartTests to true"

--- a/tests/src/components/NodeExample.bs
+++ b/tests/src/components/NodeExample.bs
@@ -7,31 +7,9 @@ function HelloFromNode(name, age) as string
 end function
 
 function UpdateState(newState) as void
-    m.top.state = newState 
+    m.top.state = newState
 end function
 
 function SetLabelText(newText) as void
     m.nameText.text = newText
 end function
-
-
-function r_real_Init() as void
-  if m.top.stubs["init"] <> invalid
-    'mock call here
-  else
-    Init()
-  end if
-end function
-
-function r_real_HelloFromNode(name, age) as string
-  return "HELLO " + name + " age:" + stri(age)
-end function
-
-function r_real_UpdateState(newState) as void
-  m.top.state = newState 
-end function
-
-function r_real_SetLabelText(newText) as void
-  m.nameText.text = newText
-end function
-

--- a/tests/src/components/NodeExample.xml
+++ b/tests/src/components/NodeExample.xml
@@ -2,4 +2,10 @@
 <component
     name="NodeExample"
     extends="Group">
+    <interface>
+        <field id="state" type="string" />
+    </interface>
+    <children>
+        <Label id="nameText" />
+    </children>
 </component>

--- a/tests/src/source/Main.bs
+++ b/tests/src/source/Main.bs
@@ -1,8 +1,5 @@
 
 function Main(args)
-
-  ? "here is my code"
-  ? "hello"
 end function
 
 function globalFunctionWithReturn() as dynamic

--- a/tests/src/source/NewExpectSyntax.spec.bs
+++ b/tests/src/source/NewExpectSyntax.spec.bs
@@ -320,6 +320,15 @@ namespace tests
     @it("stubs namespace and then cleans it")
     function _()
       getGlobalAA().wasCalled = false
+      m.stubCall(testNamespace.functionWithReturn, function()
+        m.wasCalled = true
+        return true
+      end function)
+
+      m.assertTrue(testNamespace.functionWithReturn())
+      m.assertTrue(getGlobalAA().wasCalled)
+
+      getGlobalAA().wasCalled = false
       m.stubCall(testNamespace.functionWithoutReturn, sub()
         m.wasCalled = true
       end sub)
@@ -329,6 +338,10 @@ namespace tests
 
       m.cleanMocks()
 
+      m.assertFalse(testNamespace.functionWithReturn())
+      m.assertFalse(getGlobalAA().wasCalled)
+
+      getGlobalAA().wasCalled = true
       m.assertInvalid(testNamespace.functionWithoutReturn())
       m.assertFalse(getGlobalAA().wasCalled)
 
@@ -337,6 +350,15 @@ namespace tests
 
     @it("stubs global and then cleans it")
     function _()
+      getGlobalAA().wasCalled = false
+      m.stubCall(globalFunctionWithReturn, function()
+        m.wasCalled = true
+        return true
+      end function)
+
+      m.assertTrue(globalFunctionWithReturn())
+      m.assertTrue(getGlobalAA().wasCalled)
+
       getGlobalAA().wasCalled = false
       m.stubCall(globalFunctionWithoutReturn, sub()
         m.wasCalled = true
@@ -347,6 +369,10 @@ namespace tests
 
       m.cleanMocks()
 
+      m.assertFalse(globalFunctionWithReturn())
+      m.assertFalse(getGlobalAA().wasCalled)
+
+      getGlobalAA().wasCalled = true
       m.assertInvalid(globalFunctionWithoutReturn())
       m.assertFalse(getGlobalAA().wasCalled)
 

--- a/tests/src/source/NodeExample.spec.bs
+++ b/tests/src/source/NodeExample.spec.bs
@@ -68,6 +68,29 @@ namespace tests
       m.timer.observeFieldScoped("fire", callback)
       m.timer.control = "start"
     end function
+
+    @it("updates state")
+    @params("start")
+    @params("stop")
+    @params("error")
+    function _(state)
+      m.node.top.state = ""
+      UpdateState(state)
+      m.assertEqual(m.node.top.state, state)
+    end function
+
+    @it("updates name text")
+    @params("jon")
+    @params("ringo")
+    @params("ringo")
+    @params("ringo")
+    @params("george")
+    @params("paul")
+    function _(text)
+      m.node.nameText.text = ""
+      SetLabelText(text)
+      m.assertEqual(m.node.nameText.text, text)
+    end function
   end class
 end namespace
 


### PR DESCRIPTION
requires #253 

Fixed a few issues with code coverage and improves performance. Especially when logging the results.

Example of the speed improvements on a very large clients app.

**Before**
```
reportCodeCoverage() 23031ms
```
 
**After**
```
reportCodeCoverage() 203ms
```

Also saw the cost of tracking coverage drop by around 2 seconds per run on a full pass of tests. 