### PR TITLE
Added an api to fail tests with an exception

### DIFF
--- a/framework/src/source/BaseTestSuite.bs
+++ b/framework/src/source/BaseTestSuite.bs
@@ -313,6 +313,28 @@ namespace rooibos
       return false
     end function
 
+    ' /**
+    '  * @memberof module:BaseTestSuite
+    '  * @name failCrash
+    '  * @function
+    '  * @instance
+    '  * @description Fail immediately, with the given exception
+    '  * @param {Dynamic} [error] - exception to fail on
+    '  * @param {Dynamic} [msg=""] - message to display in the test report
+    '  * @returns {boolean} - true if failure was set, false if the test is already failed
+    '  */
+    function failCrash(error as dynamic, msg = "Error" as string) as dynamic
+      if m.currentResult.isFail
+        if m.throwOnFailedAssertion
+          throw m.currentResult.getMessage()
+        end if
+        return false
+      end if
+      m.currentResult.fail(msg, m.currentAssertLineNumber)
+      m.currentResult.crash(msg, error)
+      return true
+    end function
+
     function failBecauseOfTimeOut() as dynamic
       if m.currentResult.isFail
         return false

--- a/tests/src/source/Assertion.spec.bs
+++ b/tests/src/source/Assertion.spec.bs
@@ -22,6 +22,24 @@ namespace tests
       m.assertTrue(isFail)
     end function
 
+    @only
+    @it("FailCrash")
+    function _()
+
+      try
+        result = 2 / 0
+      catch e
+        m.failCrash(e)
+      end try
+
+      isFail = m.currentResult.isFail
+      isCrash = m.currentResult.isCrash
+      m.currentResult.Reset()
+
+      m.assertTrue(isCrash)
+      m.assertTrue(isFail)
+    end function
+
     @it("AssertTrue")
     @params(true, true)
     @params(false, false)

--- a/tests/src/source/Assertion.spec.bs
+++ b/tests/src/source/Assertion.spec.bs
@@ -22,7 +22,6 @@ namespace tests
       m.assertTrue(isFail)
     end function
 
-    @only
     @it("FailCrash")
     function _()
 


### PR DESCRIPTION
example: 
```brightscript
@async
@it("loginUser success path")
function _()
	m.node.top.isLoggedIn = false
	' Success Test
	promises.chain(loginUser({
		email: "123@abc.com"
		password: "1234"
	})).catch(sub(error as dynamic)
		' Report that the test failed due to a crash
		m.testSuite.failCrash(error)
	end sub).finally(sub()
		m.testSuite.assertTrue(m.top.isLoggedIn)
		m.testSuite.done()
	end sub)
end function
```

Useful in cases where your code returns an exception to you that you want to report as a crash.