### PR TITLE
Fix missing expected lines in code coverage

### DIFF
--- a/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
+++ b/bsc-plugin/src/lib/rooibos/CodeCoverageProcessor.ts
@@ -157,8 +157,11 @@ export class CodeCoverageProcessor {
             }
         }), { walkMode: WalkMode.visitAllRecursive });
 
-
-        this.expectedCoverageMap[this.fileId.toString().trim()] = Array.from(this.coverageMap);
+        const coverageMapObject = {};
+        for (let key of this.coverageMap.keys()) {
+            coverageMapObject[key] = this.coverageMap.get(key);
+        }
+        this.expectedCoverageMap[this.fileId.toString().trim()] = coverageMapObject;
         this.filePathMap[this.fileId] = file.pkgPath;
         this.addBrsAPIText(file, astEditor);
     }
@@ -188,6 +191,7 @@ export class CodeCoverageProcessor {
     }
 
     private getFuncCallText(lineNumber: number, lineType: CodeCoverageLineType) {
+        this.coverageMap.set(lineNumber, lineType);
         return `RBS_CC_${this.fileId}_reportLine("${lineNumber.toString().trim()}", ${lineType.toString().trim()})`;
     }
 }


### PR DESCRIPTION
fixes >100% coverage reporting

- add all `getFuncCallText` to coverageMap recording
- format `expectedCoverageMap` keys as key:value objects instead of arrays to match reporting format

Note: this doesn't add full branch tracking, but at least stops the incorrect percentage stats