### PR TITLE
Made the closing of the application faster at the end of the tests

### DIFF
--- a/framework/src/source/Rooibos.bs
+++ b/framework/src/source/Rooibos.bs
@@ -34,7 +34,9 @@ namespace rooibos
 
       if runner.config.keepAppOpen = false
         ? "keepAppOpen is false; exiting Rooibos"
-        return
+        ' End statement will also exit the caller of this function
+        ' leading to an instant exit of the application
+        end
       end if
     end if
 


### PR DESCRIPTION
When testing on some applicaitons the app would hang for many seconds before closing with the `keepAppOpen` setting set to true. This will make sure the main function that is calling `rooibos_init` is also ended right away.

Failing unit tests are fixed in #271 