### PR TITLE
Fixed async tests sometimes waiting the full timeout even though the …

### DIFF
--- a/framework/src/source/TestRunner.bs
+++ b/framework/src/source/TestRunner.bs
@@ -252,7 +252,13 @@ namespace rooibos
               timeout = testSuite.asyncTimeout = invalid ? 60000 : testSuite.asyncTimeout
 
               ? "Waiting max " timeout "ms for the test suite to finish"
-              m.waitForField(node, "rooibosSuiteFinished", 10, timeout / 10)
+              t = createObject("roTimespan")
+              while node.rooibosSuiteFinished = false
+                m.wait(10)
+                if t.totalMilliseconds() >= timeout
+                  exit while
+                end if
+              end while
             end if
           end if
           nodeResults = node.asyncRooibosTestResult


### PR DESCRIPTION
…test group is completed

This issue was cased do to the flag getting flipped to true in the moments between us checking if it was done and when we started waiting for the field to change. I updated the logic to be more tailored to looping only while the value is false. Rather then the value not matching the initial value. 