### PR TITLE
Use an AA to index test suites

### DIFF
--- a/bsc-plugin/src/lib/rooibos/RooibosSession.ts
+++ b/bsc-plugin/src/lib/rooibos/RooibosSession.ts
@@ -123,8 +123,7 @@ export class RooibosSession {
             let classStatement = (runtimeConfig.ast.statements[0] as NamespaceStatement).body.statements[0] as ClassStatement;
             this.updateRunTimeConfigFunction(classStatement, editor);
             this.updateVersionTextFunction(classStatement, editor);
-            this.updateClassLookupFunction(classStatement, editor);
-            this.updateGetAllTestSuitesNames(classStatement, editor);
+            this.updateClassMapFunction(classStatement, editor);
             this.createIgnoredTestsInfoFunction(classStatement, editor);
         }
     }
@@ -191,32 +190,18 @@ export class RooibosSession {
         }
     }
 
-    updateClassLookupFunction(classStatement: ClassStatement, editor: AstEditor) {
-        let method = classStatement.methods.find((m) => m.name.text === 'getTestSuiteClassWithName');
+    updateClassMapFunction(classStatement: ClassStatement, editor: AstEditor) {
+        let method = classStatement.methods.find((m) => m.name.text === 'getTestSuiteClassMap');
         if (method) {
             editor.arrayPush(method.func.body.statements, ...Parser.parse(undent`
-                if false
-                    ? "noop" ${this.sessionInfo.testSuitesToRun.map(suite => `
-                else if name = "${suite.name}"
-                    return ${suite.classStatement.getName(ParseMode.BrightScript)}`).join('')}
-                end if
+                return {${this.sessionInfo.testSuitesToRun.map(suite => `
+                    "${suite.name}": ${suite.classStatement.getName(ParseMode.BrightScript)}`).join('')}
+                }
             `).ast.statements);
         }
     }
 
-    updateGetAllTestSuitesNames(classStatement: ClassStatement, editor: AstEditor) {
-        let method = classStatement.methods.find((m) => m.name.text === 'getAllTestSuitesNames');
-        if (method) {
-            editor.arrayPush(method.func.body.statements, ...Parser.parse([
-                'return [',
-                ...this.sessionInfo.testSuitesToRun.map((s) => `    "${s.name}"`),
-                ']'
-            ].join('\n')).ast.statements);
-        }
-    }
-
     createNodeFiles(program: Program) {
-
         for (let suite of this.sessionInfo.testSuitesToRun.filter((s) => s.isNodeTest)) {
             this.createNodeFile(program, suite);
         }

--- a/bsc-plugin/src/lib/rooibos/RooibosSessionInfo.ts
+++ b/bsc-plugin/src/lib/rooibos/RooibosSessionInfo.ts
@@ -150,6 +150,7 @@ export class SessionInfo {
             }
         }
         this.testSuitesToRun = [...this.testSuites.values()].filter((s) => s.isIncluded);
+        this.testSuitesToRun.sort((a, b) => a.name.localeCompare(b.name));
     }
 
     isExcludedByTag(item: TestCase | TestGroup | TestSuite, isParentIncluded) {

--- a/bsc-plugin/src/plugin.spec.ts
+++ b/bsc-plugin/src/plugin.spec.ts
@@ -2031,8 +2031,7 @@ describe('RooibosPlugin', () => {
             //the methods should be empty by default
             expect(findMethod('getVersionText').func.body.statements).to.be.empty;
             expect(findMethod('getRuntimeConfig').func.body.statements).to.be.empty;
-            expect(findMethod('getTestSuiteClassWithName').func.body.statements).to.be.empty;
-            expect(findMethod('getAllTestSuitesNames').func.body.statements).to.be.empty;
+            expect(findMethod('getTestSuiteClassMap').func.body.statements).to.be.empty;
             expect(findMethod('getIgnoredTestInfo').func.body.statements).to.be.empty;
 
             await builder.transpile();
@@ -2062,8 +2061,9 @@ describe('RooibosPlugin', () => {
             ).to.eql(undent`
                 function __rooibos_RuntimeConfig_builder()
                     instance = {}
-                    instance.new = sub()
-                    end sub
+                    instance.new = function()
+                        m.testSuites = m.getTestSuiteClassMap()
+                    end function
                     instance.getVersionText = function()
                         return "${version}"
                     end function
@@ -2086,20 +2086,17 @@ describe('RooibosPlugin', () => {
                             "isRecordingCodeCoverage": false
                         }
                     end function
+                    instance.getTestSuiteClassMap = function()
+                        return {
+                            "ATest1": ATest1
+                            "ATest2": ATest2
+                        }
+                    end function
                     instance.getTestSuiteClassWithName = function(name)
-                        if false
-                            ? "noop"
-                        else if name = "ATest1"
-                            return ATest1
-                        else if name = "ATest2"
-                            return ATest2
-                        end if
+                        return m.testSuites[name]
                     end function
                     instance.getAllTestSuitesNames = function()
-                        return [
-                            "ATest1"
-                            "ATest2"
-                        ]
+                        return m.testSuites.keys()
                     end function
                     instance.getIgnoredTestInfo = function()
                         return {
@@ -2119,8 +2116,7 @@ describe('RooibosPlugin', () => {
             //the methods should be empty again after transpile has finished
             expect(findMethod('getVersionText').func.body.statements).to.be.empty;
             expect(findMethod('getRuntimeConfig').func.body.statements).to.be.empty;
-            expect(findMethod('getTestSuiteClassWithName').func.body.statements).to.be.empty;
-            expect(findMethod('getAllTestSuitesNames').func.body.statements).to.be.empty;
+            expect(findMethod('getTestSuiteClassMap').func.body.statements).to.be.empty;
             expect(findMethod('getIgnoredTestInfo').func.body.statements).to.be.empty;
         });
 
@@ -2152,8 +2148,9 @@ describe('RooibosPlugin', () => {
                 ).to.eql(undent`
                     function __rooibos_RuntimeConfig_builder()
                         instance = {}
-                        instance.new = sub()
-                        end sub
+                        instance.new = function()
+                            m.testSuites = m.getTestSuiteClassMap()
+                        end function
                         instance.getVersionText = function()
                             return "${version}"
                         end function
@@ -2176,13 +2173,14 @@ describe('RooibosPlugin', () => {
                                 "isRecordingCodeCoverage": false
                             }
                         end function
+                        instance.getTestSuiteClassMap = function()
+                            return {}
+                        end function
                         instance.getTestSuiteClassWithName = function(name)
-                            if false
-                                ? "noop"
-                            end if
+                            return m.testSuites[name]
                         end function
                         instance.getAllTestSuitesNames = function()
-                            return []
+                            return m.testSuites.keys()
                         end function
                         instance.getIgnoredTestInfo = function()
                             return {

--- a/framework/src/source/BaseTestSuite.bs
+++ b/framework/src/source/BaseTestSuite.bs
@@ -1908,7 +1908,7 @@ namespace rooibos
       '   m.currentResult.fail("Setting up mock failed: " + error.message, m.currentAssertLineNumber)
       '   return false
       ' end try
-      return false
+      ' return false
     end function
 
     ' /**

--- a/framework/src/source/RuntimeConfig.bs
+++ b/framework/src/source/RuntimeConfig.bs
@@ -1,16 +1,25 @@
 namespace rooibos
   class RuntimeConfig
 
+    function new()
+      m.testSuites = m.getTestSuiteClassMap()
+    end function
+
     function getVersionText()
     end function
 
     function getRuntimeConfig()
     end function
 
+    function getTestSuiteClassMap()
+    end function
+
     function getTestSuiteClassWithName(name)
+      return m.testSuites[name]
     end function
 
     function getAllTestSuitesNames()
+      return m.testSuites.keys()
     end function
 
     function getIgnoredTestInfo()


### PR DESCRIPTION
Rooibos currently uses an if-switch statement block to determine which test suites should be run. This results in lots of duplicate code, and usually having a Roku compiler error due to bytecode chunk constant limitations when too many test suites are present.

```
------ Compiling dev 'unit-tests-v5' ------
*** ERROR compiling pkg:/source/rooibos/RuntimeConfig.brs(NaN)
06-25 18:31:42.680 [plg.dbg.conn.wait] Waiting for debugging connection
06-25 18:31:42.690 [plg.dbg.conn.wait] Waiting for debugger on 10.18.5.243:8081
06-25 18:31:42.697 [plg.dbg.conn.ok] remote debugger connected
Internal limit size exceeded. (compile error &hae) in pkg:/source/rooibos/RuntimeConfig.brs(734)
```
<sup>This happens with the latest Rooibos version when I have >=300 test suites. I usually have to batch them so the devices in my CI don't freak out.</sup>

Here's an example of what `source/rooibos/RuntimeConfig.brs` looks like at the moment:

```brightscript
    instance.getTestSuiteClassWithName = function(name)
        if false
            ? "noop"
        else if name = "AtlantisInitCompleteEventCommandTests"
            return tests_AtlantisInitCompleteEventCommandTests
        else if name = "AppLaunchedCommandTests"
            return tests_AppLaunchedCommandTests
        else if name = "ArrayUtilsTests"
            return tests_ArrayUtilsTests
        else if name = "AppPopupConfirmationPageControllerTests"
            return tests_AppPopupConfirmationPageControllerTests
        else if name = "AudioSubtitlesModelTests"
            return tests_AudioSubtitlesModelTests
        else if name = "AddToSmartlistCommandTests"
            return tests_AddToSmartlistCommandTests
        else if name = "ABModelTests"
            return tests_ABModelTests
        else if name = "AuthenticationServiceAuthenticateErrorAdaptorTests"
            return tests_AuthenticationServiceAuthenticateErrorAdaptorTests
        else if name = "AuthenticationServiceSuccessResponseAdapterTests"
            return tests_AuthenticationServiceSuccessResponseAdapterTests
        else if name = "AccountPageControllerTests"
            return tests_AccountPageControllerTests
        else if name = "AuthenticationServiceCaptchaAdapterTests"
            return tests_AuthenticationServiceCaptchaAdapterTests
        else if name = "AuthenticationServiceSignUpErrorResponseAdapterTests"
            return tests_AuthenticationServiceSignUpErrorResponseAdapterTests
        else if name = "AuthenticationServiceSignInErrorAdapterTests"
            return tests_AuthenticationServiceSignInErrorAdapterTests
        else if name = "ABServiceTests"
            return tests_ABServiceTests
        else if name = "AuthenticationAgentTests"
            return tests_AuthenticationAgentTests
        else if name = "AbstractAssetDecoratorTests"
            return tests_AbstractAssetDecoratorTests
        else if name = "AbstractMenuDecoratorTests"
            return tests_AbstractMenuDecoratorTests
        else if name = "AuthenticationServiceTests"
            return tests_AuthenticationServiceTests
        else if name = "AbstractSeasonSeriesDecoratorTests"
            return tests_AbstractSeasonSeriesDecoratorTests
        else if name = "AssetEpisodeDecoratorTests"
            return tests_AssetEpisodeDecoratorTests
        else if name = "AssetLinearSlotDecoratorTests"
            return tests_AssetLinearSlotDecoratorTests
        else if name = "AssetLinearDecoratorTests"
            return tests_AssetLinearDecoratorTests
        else if name = "AssetSLEDecoratorTests"
            return tests_AssetSLEDecoratorTests
        else if name = "AssetShortformDecoratorTests"
            return tests_AssetShortformDecoratorTests
        else if name = "AtlantisUtilsTests"
            return tests_AtlantisUtilsTests
        else if name = "AsyncMessageEntitlementsChangedCommandTests"
            return tests_AsyncMessageEntitlementsChangedCommandTests
        else if name = "AssetMovieDecoratorTests"
            return tests_AssetMovieDecoratorTests
        else if name = "AsyncGetSettingsNodeJobTests"
            return tests_AsyncGetSettingsNodeJobTests
        else if name = "AsyncNotificationsModelTests"
            return tests_AsyncNotificationsModelTests
        else if name = "AsyncNotificationsServiceTests"
            return tests_AsyncNotificationsServiceTests
        else if name = "AuthenticationServiceSignInTemplateAdapterTests"
            return tests_AuthenticationServiceSignInTemplateAdapterTests
        end if
    end function
    instance.getAllTestSuitesNames = function()
        return [
            "AtlantisInitCompleteEventCommandTests"
            "AppLaunchedCommandTests"
            "ArrayUtilsTests"
            "AppPopupConfirmationPageControllerTests"
            "AudioSubtitlesModelTests"
            "AddToSmartlistCommandTests"
            "ABModelTests"
            "AuthenticationServiceAuthenticateErrorAdaptorTests"
            "AuthenticationServiceSuccessResponseAdapterTests"
            "AccountPageControllerTests"
            "AuthenticationServiceCaptchaAdapterTests"
            "AuthenticationServiceSignUpErrorResponseAdapterTests"
            "AuthenticationServiceSignInErrorAdapterTests"
            "ABServiceTests"
            "AuthenticationAgentTests"
            "AbstractAssetDecoratorTests"
            "AbstractMenuDecoratorTests"
            "AuthenticationServiceTests"
            "AbstractSeasonSeriesDecoratorTests"
            "AssetEpisodeDecoratorTests"
            "AssetLinearSlotDecoratorTests"
            "AssetLinearDecoratorTests"
            "AssetSLEDecoratorTests"
            "AssetShortformDecoratorTests"
            "AtlantisUtilsTests"
            "AsyncMessageEntitlementsChangedCommandTests"
            "AssetMovieDecoratorTests"
            "AsyncGetSettingsNodeJobTests"
            "AsyncNotificationsModelTests"
            "AsyncNotificationsServiceTests"
            "AuthenticationServiceSignInTemplateAdapterTests"
        ]
    end function
```

This PR changes that to use an AA instead, which uses up less code:

```brightscript
    instance.getTestSuiteClassMap = function()
        return {
            "ABModelTests": tests_ABModelTests
            "ABServiceTests": tests_ABServiceTests
            "AbstractAssetDecoratorTests": tests_AbstractAssetDecoratorTests
            "AbstractMenuDecoratorTests": tests_AbstractMenuDecoratorTests
            "AbstractSeasonSeriesDecoratorTests": tests_AbstractSeasonSeriesDecoratorTests
            "AccountPageControllerTests": tests_AccountPageControllerTests
            "AddToSmartlistCommandTests": tests_AddToSmartlistCommandTests
            "AppLaunchedCommandTests": tests_AppLaunchedCommandTests
            "AppPopupConfirmationPageControllerTests": tests_AppPopupConfirmationPageControllerTests
            "ArrayUtilsTests": tests_ArrayUtilsTests
            "AssetEpisodeDecoratorTests": tests_AssetEpisodeDecoratorTests
            "AssetLinearDecoratorTests": tests_AssetLinearDecoratorTests
            "AssetLinearSlotDecoratorTests": tests_AssetLinearSlotDecoratorTests
            "AssetMovieDecoratorTests": tests_AssetMovieDecoratorTests
            "AssetShortformDecoratorTests": tests_AssetShortformDecoratorTests
            "AssetSLEDecoratorTests": tests_AssetSLEDecoratorTests
            "AsyncGetSettingsNodeJobTests": tests_AsyncGetSettingsNodeJobTests
            "AsyncMessageEntitlementsChangedCommandTests": tests_AsyncMessageEntitlementsChangedCommandTests
            "AsyncNotificationsModelTests": tests_AsyncNotificationsModelTests
            "AsyncNotificationsServiceTests": tests_AsyncNotificationsServiceTests
            "AtlantisInitCompleteEventCommandTests": tests_AtlantisInitCompleteEventCommandTests
            "AtlantisUtilsTests": tests_AtlantisUtilsTests
            "AudioSubtitlesModelTests": tests_AudioSubtitlesModelTests
            "AuthenticationAgentTests": tests_AuthenticationAgentTests
            "AuthenticationServiceAuthenticateErrorAdaptorTests": tests_AuthenticationServiceAuthenticateErrorAdaptorTests
            "AuthenticationServiceCaptchaAdapterTests": tests_AuthenticationServiceCaptchaAdapterTests
            "AuthenticationServiceSignInErrorAdapterTests": tests_AuthenticationServiceSignInErrorAdapterTests
            "AuthenticationServiceSignInTemplateAdapterTests": tests_AuthenticationServiceSignInTemplateAdapterTests
            "AuthenticationServiceSignUpErrorResponseAdapterTests": tests_AuthenticationServiceSignUpErrorResponseAdapterTests
            "AuthenticationServiceSuccessResponseAdapterTests": tests_AuthenticationServiceSuccessResponseAdapterTests
            "AuthenticationServiceTests": tests_AuthenticationServiceTests
        }
    end function
    instance.getTestSuiteClassWithName = function(name)
        return m.testSuites[name]
    end function
    instance.getAllTestSuitesNames = function()
        return m.testSuites.keys()
    end function
```

Some notes:

- In theory, this code should be faster to execute, as map lookups should be faster than arbitrary `if` checks in large collections.
- This change should also allow for more suites to be included before the Roku compiler freaks out.
- Because of `m.testSuites.keys()`, this change has the unintended side-effect of ensuring A-Z sorting of all test suites. I've made it less unintended by having the plugin sort the `testSuitesToRun` array.