### PR TITLE
Sets default types for `m.top` and `m.node` in BaseTestSuite

### DIFF
--- a/bsc-plugin/src/plugin.spec.ts
+++ b/bsc-plugin/src/plugin.spec.ts
@@ -2253,6 +2253,9 @@ describe('RooibosPlugin', () => {
     });
 
     describe.skip('run a local project', () => {
+
+        // TODO: This project should include its own app to run tests on
+        // Perhaps using https://github.com/lvcabral/brs-engine to run non-node tests
         it('sanity checks on parsing - only run this outside of ci', () => {
             let programBuilder = new ProgramBuilder();
             let swv = {

--- a/framework/src/source/BaseTestSuite.bs
+++ b/framework/src/source/BaseTestSuite.bs
@@ -69,7 +69,12 @@ namespace rooibos
 
     public isDoneCalled = false
 
-    public top as NodeWithRooibosFields = invalid
+    ' Reference to the tested node in Node tests
+    ' Defined as object so it can be easily typed in tests
+    public top as object = invalid
+    ' Reference to the 'm' of the tested node in node tests
+    ' Defined as object so it can be easily typed in tests
+    public node as object = invalid
 
     public tests as Test[] = []
 
@@ -200,23 +205,24 @@ namespace rooibos
         m.finishAsyncGroups()
       else
         group = m.currentGroup
-        m.testRunner.top.rooibosGroupFinished = false
+        testRunnerTop as NodeWithRooibosFields = m.testRunner.top
+        testRunnerTop.rooibosGroupFinished = false
 
         ? ""
         ? rooibos.common.fillText(">>>> Describe: " + group.name, ">", 80)
         ? `  Location: file://${group.testSuite.filePath.trim()}:${group.lineNumber}`
         ? ""
 
-        m.testRunner.top.observeFieldScoped("rooibosGroupFinished", "rooibos_onGroupComplete")
+        testRunnerTop.observeFieldScoped("rooibosGroupFinished", "rooibos_onGroupComplete")
 
         group.run()
 
         if group.stats.hasFailures
           ? "Group failed before any async code could be executed"
-          m.testRunner.top.unobserveFieldScoped("rooibosGroupFinished")
+          testRunnerTop.unobserveFieldScoped("rooibosGroupFinished")
           ' m.testGroupDone()
           m.onAsyncGroupComplete(group)
-        else if m.testRunner.top.rooibosGroupFinished
+        else if testRunnerTop.rooibosGroupFinished
           m.onAsyncGroupComplete(group)
         end if
 
@@ -2677,14 +2683,14 @@ namespace rooibos
 
     function setAsync(isAsync as boolean)
       ? "Setting current test to async " isAsync
-      m.top.rooibosTestIsAsync = isAsync
+      (m.top as NodeWithRooibosFields).rooibosTestIsAsync = isAsync
     end function
 
     function done()
       ' ? "Async test is complete"
       if m.isDoneCalled = false
         m.isDoneCalled = true
-        m.top.rooibosTestFinished = true
+        (m.top as NodeWithRooibosFields).rooibosTestFinished = true
       else
         ? "WARNING - extra done call after test is done ! Did you properly clean up your observers?"
       end if
@@ -2692,12 +2698,12 @@ namespace rooibos
 
     function testSuiteDone()
       ' ? "Async suite is complete"
-      m.top.rooibosSuiteFinished = true
+      (m.top as NodeWithRooibosFields).rooibosSuiteFinished = true
     end function
 
     function testGroupDone()
       ? "Async group is complete"
-      m.top.rooibosGroupFinished = true
+      (m.top as NodeWithRooibosFields).rooibosGroupFinished = true
     end function
 
     function assertAsyncField(target, fieldName, delay = 500, maxAttempts = 10)

--- a/framework/src/source/TestGroup.bs
+++ b/framework/src/source/TestGroup.bs
@@ -135,7 +135,8 @@ namespace rooibos
         'finished
         m.finishAsyncTests()
       else
-        m.testRunner.top.rooibosTestFinished = false
+        testRunnerTop as NodeWithRooibosFields = m.testRunner.top
+        testRunnerTop.rooibosTestFinished = false
         isOk = m.runSuiteFunction(m.beforeEachFunctionName, "beforeEach", m.currentTest)
         if isOk
           'TODO - set a timeout here
@@ -143,10 +144,10 @@ namespace rooibos
           if currentTest?.isAsync <> true
             ? "Executing test synchronously"
             m.testSuite.runTest(currentTest)
-            m.testRunner.top.rooibosTestFinished = true
+            testRunnerTop.rooibosTestFinished = true
             m.onAsyncTestComplete()
           else
-            m.testRunner.top.observeFieldScoped("rooibosTestFinished", "rooibos_onTestComplete")
+            testRunnerTop.observeFieldScoped("rooibosTestFinished", "rooibos_onTestComplete")
             if currentTest.isAsync = true
               m.testSuite.setTestTimer(currentTest.asyncTimeout)
             end if
@@ -154,8 +155,8 @@ namespace rooibos
 
             if currentTest.result.isFail
               ? "Test failed before any async code could be executed"
-              m.testRunner.top.unobserveFieldScoped("rooibosTestFinished")
-              m.testRunner.top.rooibosTestFinished = true
+              testRunnerTop.unobserveFieldScoped("rooibosTestFinished")
+              testRunnerTop.rooibosTestFinished = true
               m.onAsyncTestComplete()
             end if
           end if

--- a/framework/src/source/TestRunner.bs
+++ b/framework/src/source/TestRunner.bs
@@ -17,7 +17,8 @@ namespace rooibos
     public testSuites as BaseTestSuite[] = []
     private runtimeConfig as RuntimeConfig = invalid
     private stats as Stats = invalid
-    public top as NodeWithRooibosFields = invalid
+    public top as roSGNode = invalid
+    public node as roAssociativeArray = invalid
     private nodeTestName = ""
     private currentTestSuite as BaseTestSuite = invalid
     public currentGroup as TestGroup = invalid
@@ -151,10 +152,10 @@ namespace rooibos
         m.nodeTestName = nodeTestName
         m.nodeContext.testRunner = m
         m.nodeContext.top.addFields({
-          "rooibosSuiteFinished": false
-          "rooibosTestFinished": false
-          "rooibosTestIsAsync": false
-          "rooibosGroupFinished": false
+          rooibosSuiteFinished: false
+          rooibosTestFinished: false
+          rooibosTestIsAsync: false
+          rooibosGroupFinished: false
         })
 
       end if
@@ -244,7 +245,7 @@ namespace rooibos
         ? " +++++RUNNING NODE TEST"
         ? " node type is " ; testSuite.generatedNodeName
 
-        node = m.testScene.createChild(testSuite.generatedNodeName)
+        node = m.testScene.createChild(testSuite.generatedNodeName) as NodeWithRooibosFields
         'wait on the field
 
         if type(node) = "roSGNode"
@@ -276,7 +277,7 @@ namespace rooibos
           else
             ? " ERROR! The node test"; testSuite.name; " did not indicate test completion. Did you call m.done() in your test? Did you correctly configure your node test? Please refer to : https://github.com/rokucommunity/rooibos/blob/master/docs/index.md#testing-scenegraph-nodes"
           end if
-          m.testScene.removeChild(node)
+          m.testScene.removeChild(node as roSGNode)
           return
 
         else
@@ -362,6 +363,13 @@ namespace rooibos
     rooibosTestFinished as boolean
     rooibosTestIsAsync as boolean
     rooibosGroupFinished as boolean
+    asyncRooibosTestResult
+  end interface
+
+  interface AsyncRooibosTestResult
+    stats as rooibos.Stats
+    tests as rooibos.Test[]
+    groups as rooibos.TestGroup[]
   end interface
 
 end namespace

--- a/framework/src/source/TestRunner.bs
+++ b/framework/src/source/TestRunner.bs
@@ -18,7 +18,6 @@ namespace rooibos
     private runtimeConfig as RuntimeConfig = invalid
     private stats as Stats = invalid
     public top as roSGNode = invalid
-    public node as roAssociativeArray = invalid
     private nodeTestName = ""
     private currentTestSuite as BaseTestSuite = invalid
     public currentGroup as TestGroup = invalid

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -15,8 +15,7 @@
         "dotenv": "^16.4.5",
         "roku-debug": "^0.21.10",
         "roku-deploy": "^4.0.0-alpha.1",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.4"
+        "ts-node": "^10.7.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2970,6 +2969,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5365,42 +5365,6 @@
         }
       }
     },
-    "rooibos": {
-      "version": "file:../bsc-plugin",
-      "requires": {
-        "@types/chai": "^4.1.2",
-        "@types/events": "^3.0.0",
-        "@types/fs-extra": "^5.0.1",
-        "@types/mocha": "^9.1.1",
-        "@types/node": "^14.18.41",
-        "@types/yargs": "^15.0.5",
-        "@typescript-eslint/eslint-plugin": "^5.27.0",
-        "@typescript-eslint/parser": "^5.27.0",
-        "brighterscript": "^0.67.4",
-        "chai": "^4.2.0",
-        "chai-subset": "^1.6.0",
-        "coveralls": "^3.0.0",
-        "cz-conventional-changelog": "^3.3.0",
-        "eslint": "^8.16.0",
-        "eslint-plugin-no-only-tests": "^2.4.0",
-        "fs-extra": "^10.1.0",
-        "minimatch": "^3.0.4",
-        "mocha": "^9.1.3",
-        "nyc": "^15.1.0",
-        "release-it": "^17.6.0",
-        "roku-debug": "^0.21.10",
-        "roku-deploy": "^3.12.1",
-        "source-map": "^0.7.3",
-        "source-map-support": "^0.5.13",
-        "trim-whitespace": "^1.3.3",
-        "ts-node": "^9.0.0",
-        "typescript": "^4.9.5",
-        "undent": "^0.1.0",
-        "vscode-languageserver": "~6.1.1",
-        "vscode-languageserver-protocol": "~3.15.3",
-        "yargs": "^16.2.0"
-      }
-    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5637,7 +5601,8 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "undici-types": {
       "version": "5.26.5",

--- a/tests/src/source/Assertion.spec.bs
+++ b/tests/src/source/Assertion.spec.bs
@@ -1,6 +1,3 @@
-import "pkg:/source/rooibos/BaseTestSuite.bs"
-
-
 namespace tests
 
   @noEarlyExit


### PR DESCRIPTION
This makes it so tests that use `m.top` and `m.node` without first typing them work without validation errors.

