### PR TITLE
Removes arbitrary limits from eqValues & eqArray

### DIFF
--- a/framework/src/source/CommonUtils.bs
+++ b/framework/src/source/CommonUtils.bs
@@ -645,11 +645,6 @@ namespace rooibos.common
   '  * @returns {boolean} - True if values are equal or False in other case.
   '  */
   function eqValues(Value1, Value2, fuzzy = false, callCount = 0) as dynamic
-    if callCount > 10
-      ? "REACHED MAX ITERATIONS DOING COMPARISON"
-      return true
-    end if
-
     ' Workaraund for bug with string boxing, and box everything else
     val1Type = rooibos.common.getSafeType(Value1)
     val2Type = rooibos.common.getSafeType(Value2)
@@ -769,10 +764,6 @@ namespace rooibos.common
   '  * @returns {boolean} - True if arrays are equal or False in other case.
   '  */
   function eqArray(Value1, Value2, fuzzy = false, callCount = 0) as dynamic
-    if callCount > 30
-      ? "REACHED MAX ITERATIONS DOING COMPARISON"
-      return true
-    end if
     if not (rooibos.common.isArray(Value1)) or not rooibos.common.isArray(Value2)
       return false
     end if


### PR DESCRIPTION
We're seeing `REACHED MAX ITERATIONS DOING COMPARISON` warnings in our unit tests which can potentially result in false positives since `true` is always returned once the call count is reached. 

I was in the process of making this max iteration count configurable but what would be a sensible default? Should we enforce a max call count outside the BrightScript engine?

As it stands, these warnings are logged to console and are easily missed, especially when the test suite is of a significant size. 

These changes are a proposal to remove the hardcoded call count in favour of letting BrightScript enforce stack limits.



