### PR TITLE
missing floating point precision and incorrect failure states

### DIFF
--- a/framework/src/source/rooibos/BaseTestSuite.bs
+++ b/framework/src/source/rooibos/BaseTestSuite.bs
@@ -347,7 +347,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -372,7 +372,7 @@ namespace rooibos
 
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -400,7 +400,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -428,7 +428,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -456,7 +456,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -481,7 +481,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -505,7 +505,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -538,7 +538,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -572,7 +572,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -625,7 +625,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -674,7 +674,7 @@ namespace rooibos
 
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -708,7 +708,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -778,7 +778,7 @@ namespace rooibos
                 end for 'values to match
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -814,7 +814,7 @@ namespace rooibos
 
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -884,7 +884,7 @@ namespace rooibos
                 end for
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -954,7 +954,7 @@ namespace rooibos
                 end for
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1001,7 +1001,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1049,7 +1049,7 @@ namespace rooibos
 
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1100,7 +1100,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1151,7 +1151,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1212,7 +1212,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1276,7 +1276,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1312,7 +1312,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1361,7 +1361,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1408,7 +1408,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1450,7 +1450,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1489,7 +1489,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1529,7 +1529,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1564,7 +1564,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1613,7 +1613,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1648,7 +1648,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1718,7 +1718,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, error.message)
+                m.failCrash(error, error.message)
             end try
             return false
         end function
@@ -1785,7 +1785,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function
@@ -1856,7 +1856,7 @@ namespace rooibos
                 end if
                 return true
             catch error
-                m.currentResult.failCrash(error, msg)
+                m.failCrash(error, msg)
             end try
             return false
         end function

--- a/framework/src/source/rooibos/CommonUtils.bs
+++ b/framework/src/source/rooibos/CommonUtils.bs
@@ -291,7 +291,7 @@ namespace rooibos.common
             valueAsStr = value.toStr("%.40f")
 
             if valueAsStr.inStr(".") > -1 then
-                ' remove trailing zeros for integers
+                ' remove trailing zeros resulting from the high precision string formatting
                 while valueAsStr.endsWith("0")
                     valueAsStr = valueAsStr.left(len(valueAsStr) - 1)
                 end while

--- a/framework/src/source/rooibos/CommonUtils.bs
+++ b/framework/src/source/rooibos/CommonUtils.bs
@@ -207,7 +207,7 @@ namespace rooibos.common
             valueAsStr = value.toStr("%.40f")
 
             if valueAsStr.inStr(".") > -1 then
-                ' remove trailing zeros for integers
+                ' remove trailing zeros resulting from the high precision string formatting
                 while valueAsStr.endsWith("0")
                     valueAsStr = valueAsStr.left(len(valueAsStr) - 1)
                 end while

--- a/framework/src/source/rooibos/CommonUtils.bs
+++ b/framework/src/source/rooibos/CommonUtils.bs
@@ -204,10 +204,24 @@ namespace rooibos.common
                 return value.ToStr()
             end if
         else if rooibos.common.isFloat(value) or rooibos.common.isDouble(value) then
+            valueAsStr = value.toStr("%.40f")
+
+            if valueAsStr.inStr(".") > -1 then
+                ' remove trailing zeros for integers
+                while valueAsStr.endsWith("0")
+                    valueAsStr = valueAsStr.left(len(valueAsStr) - 1)
+                end while
+            end if
+
+            if valueAsStr.endsWith(".") then
+                ' remove trailing dot
+                valueAsStr = valueAsStr.left(len(valueAsStr) - 1)
+            end if
+
             if includeType then
-                return Str(value).Trim() + " (" + rooibos.common.getSafeType(value) + ")"
+                return valueAsStr.Trim() + " (" + rooibos.common.getSafeType(value) + ")"
             else
-                return Str(value).Trim()
+                return valueAsStr.Trim()
             end if
         else if type(value) = "roSGNode" then
             return "Node(" + value.subType() + ")"
@@ -274,10 +288,24 @@ namespace rooibos.common
                 return value.ToStr()
             end if
         else if rooibos.common.isFloat(value) or rooibos.common.isDouble(value) then
+            valueAsStr = value.toStr("%.40f")
+
+            if valueAsStr.inStr(".") > -1 then
+                ' remove trailing zeros for integers
+                while valueAsStr.endsWith("0")
+                    valueAsStr = valueAsStr.left(len(valueAsStr) - 1)
+                end while
+            end if
+
+            if valueAsStr.endsWith(".") then
+                ' remove trailing dot
+                valueAsStr = valueAsStr.left(len(valueAsStr) - 1)
+            end if
+
             if includeType then
-                return Str(value).Trim() + " (" + rooibos.common.getSafeType(value) + ")"
+                return valueAsStr.Trim() + " (" + rooibos.common.getSafeType(value) + ")"
             else
-                return Str(value).Trim()
+                return valueAsStr.Trim()
             end if
         else if type(value) = "roSGNode" then
             return "Node(" + value.subType() + ")"
@@ -665,6 +693,16 @@ namespace rooibos.common
         if not l1 = l2 then
             return false
         else
+            customFieldKey = "__rooibos_Custom_Eq_Field_" + createObject("roDeviceInfo").getRandomUUID()
+            Value1[customFieldKey] = createObject("roDeviceInfo").getRandomUUID()
+            if Value2.ifAssociativeArray.doesExist(customFieldKey) then
+                if rooibos.common.isString(Value2[customFieldKey]) and Value1[customFieldKey] = Value2[customFieldKey] then
+                    ' If the custom field is present and equal, we can skip it in the comparison
+                    Value1.ifAssociativeArray.delete(customFieldKey)
+                    return true
+                end if
+            end if
+
             for each k in Value1
                 if not Value2.ifAssociativeArray.DoesExist(k) then
                     return false

--- a/framework/src/source/rooibos/CommonUtils.bs
+++ b/framework/src/source/rooibos/CommonUtils.bs
@@ -693,16 +693,6 @@ namespace rooibos.common
         if not l1 = l2 then
             return false
         else
-            customFieldKey = "__rooibos_Custom_Eq_Field_" + createObject("roDeviceInfo").getRandomUUID()
-            Value1[customFieldKey] = createObject("roDeviceInfo").getRandomUUID()
-            if Value2.ifAssociativeArray.doesExist(customFieldKey) then
-                if rooibos.common.isString(Value2[customFieldKey]) and Value1[customFieldKey] = Value2[customFieldKey] then
-                    ' If the custom field is present and equal, we can skip it in the comparison
-                    Value1.ifAssociativeArray.delete(customFieldKey)
-                    return true
-                end if
-            end if
-
             for each k in Value1
                 if not Value2.ifAssociativeArray.DoesExist(k) then
                     return false

--- a/test-project/src/source/CommonUtils.spec.bs
+++ b/test-project/src/source/CommonUtils.spec.bs
@@ -1,0 +1,40 @@
+import "pkg:/source/rooibos/BaseTestSuite.bs"
+import "pkg:/source/rooibos/CommonUtils.bs"
+
+namespace tests
+
+    @noEarlyExit
+    @suite("Rooibos CommonUtils tests")
+    class CommonUtilsTests extends rooibos.BaseTestSuite
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("asMultilineString()")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @it("correctly handles floats")
+        function _()
+            varA! = 157.3333282470703
+            objA = { a: varA! }
+            varB! = 157.3332977294922
+            objB = { a: varB! }
+
+            m.assertEqual(rooibos.Common.asMultilineString(objA), `{\n  "a": 157.3333282470703125\n}`)
+            m.assertEqual(rooibos.Common.asMultilineString(objB), `{\n  "a": 157.3332977294921875\n}`)
+        end function
+
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        @describe("asString()")
+        '+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+        @it("correctly handles floats")
+        function _()
+            varA! = 157.3333282470703
+            objA = { a: varA! }
+            varB! = 157.3332977294922
+            objB = { a: varB! }
+
+            m.assertEqual(rooibos.Common.asString(objA), `{a:157.3333282470703125}`)
+            m.assertEqual(rooibos.Common.asString(objB), `{a:157.3332977294921875}`)
+        end function
+    end class
+end namespace


### PR DESCRIPTION
This pull request primarily refactors exception handling in the `BaseTestSuite` to simplify error reporting, and improves the string representation of floating-point numbers in `CommonUtils`. The key changes are grouped below:

Exception handling improvements in test suite:

* Replaced all occurrences of `m.currentResult.failCrash(error, msg)` with `m.failCrash(error, msg)` throughout the `BaseTestSuite.bs` file to correct error handling and overriding of the current failure reason. [[1]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL350-R350) [[2]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL375-R375) [[3]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL403-R403) [[4]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL431-R431) [[5]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL459-R459) [[6]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL484-R484) [[7]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL508-R508) [[8]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL541-R541) [[9]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL575-R575) [[10]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL628-R628) [[11]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL677-R677) [[12]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL711-R711) [[13]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL781-R781) [[14]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL817-R817) [[15]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL887-R887) [[16]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL957-R957) [[17]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1004-R1004) [[18]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1052-R1052) [[19]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1103-R1103) [[20]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1154-R1154) [[21]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1215-R1215) [[22]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1279-R1279) [[23]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1315-R1315) [[24]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1364-R1364) [[25]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1411-R1411) [[26]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1453-R1453) [[27]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1492-R1492) [[28]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1532-R1532) [[29]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1567-R1567) [[30]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1616-R1616) [[31]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1651-R1651) [[32]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1721-R1721) [[33]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1788-R1788) [[34]](diffhunk://#diff-5bd71374d5721a40903caa31917ff4492a4d7ee5df314d18a8ba5a5e9cf9b39dL1859-R1859)

String formatting improvements for floating-point numbers:

* Enhanced the handling of floats and doubles values in `rooibos.common.toString` and `rooibos.common.asMultilineString` by formatting to a very high precision and then removing trailing zeros and unnecessary decimal points. [[1]](diffhunk://#diff-370897a256dc0793257315a45989f21d70647f82f2c515cee841632e15279badR207-R224) [[2]](diffhunk://#diff-370897a256dc0793257315a45989f21d70647f82f2c515cee841632e15279badR291-R308)