### PR TITLE
chore: Make `getTestFunctionContents` test helper more flexible for later bsc version usage

### DIFF
--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -2868,9 +2868,22 @@ function getContents(filename: string) {
 function getTestFunctionContents() {
     const contents = getContents('test.spec.brs');
 
-    let [, result] = /instance.[\w_]+\s?\= function\((?:[\w,\s]*)\)\s?([\S\s]*|.*)(?=^\s*end function\s+instance\.)/img.exec(contents);
+    //try to find inline function
+    let [, result] = /instance.rooiboos_test_case_[\w_]+\s?\= function\((?:[\w,\s]*)\)\s?([\S\s]*|.*)(?=^\s*end function\s+instance\.)/img.exec(contents) ?? [];
+    if (result) {
+        return undent(result);
+    }
 
-    return undent(result);
+    //try to find a hoisted version of the function
+    let [, testName] = /instance.rooiboos_test_case_[\w_]+\s?\=\s?([\w_]+)/img.exec(contents) ?? [];
+    if (testName) {
+        //find the function contents by this name
+        let [, result] = new RegExp(`(?:function|sub)\\s+${testName}\\((?:[\\w,\\s]*)\\)\\s?([\\S\\s]*|.*)(?=^\\s*end function)`, 'img').exec(contents) ?? [];
+        if (result) {
+            return undent(result);
+        }
+    }
+    return undefined;
 }
 
 function getTestSubContents() {


### PR DESCRIPTION
bsc v0.7.0+ started rewriting class methods to be globally named, which messed up the rooibos unit testing logic that expected them to always be inlined. This change grabs the test body contents from _either_ approach now. Many of the tests will still fail because we need to rewrite their expected results, but at least now only full class tests will fail. 