### PR TITLE
Add a node creator for generated test nodes

### DIFF
--- a/framework/src/components/rooibos/RooibosNodeCreator.brs
+++ b/framework/src/components/rooibos/RooibosNodeCreator.brs
@@ -4,6 +4,6 @@ function Init()
     m.global.removeField("__rooibos_node_creator")
 end function
 
-function CreateNode(nodeName as dynamic, parent as roSGNode) as roSGNode
+function CreateNode(nodeName as dynamic, parent as dynamic) as dynamic
     return parent.CreateChild(nodeName)
 end function

--- a/framework/src/components/rooibos/RooibosNodeCreator.bs
+++ b/framework/src/components/rooibos/RooibosNodeCreator.bs
@@ -1,0 +1,9 @@
+function Init()
+    ' Forces the current node to become owned by the render thread
+    m.global.update({ "__rooibos_node_creator": m.top }, true)
+    m.global.removeField("__rooibos_node_creator")
+end function
+
+function CreateNode(nodeName as dynamic, parent as roSGNode) as roSGNode
+    return parent.CreateChild(nodeName)
+end function

--- a/framework/src/components/rooibos/RooibosNodeCreator.xml
+++ b/framework/src/components/rooibos/RooibosNodeCreator.xml
@@ -1,0 +1,5 @@
+<component name="RooibosNodeCreator" extends="Node">
+    <interface>
+        <function name="CreateNode" />
+    </interface>
+</component>

--- a/framework/src/components/rooibos/RooibosNodeCreator.xml
+++ b/framework/src/components/rooibos/RooibosNodeCreator.xml
@@ -1,4 +1,5 @@
 <component name="RooibosNodeCreator" extends="Node">
+    <script type="text/brightscript" uri="RooibosNodeCreator.brs" />
     <interface>
         <function name="CreateNode" />
     </interface>

--- a/framework/src/source/rooibos/TestRunner.bs
+++ b/framework/src/source/rooibos/TestRunner.bs
@@ -223,7 +223,8 @@ namespace rooibos
             if testSuite.generatedNodeName <> "" then
                 rooibos.common.logDebug(`+++++RUNNING NODE TEST${chr(10)}node type is ${testSuite.generatedNodeName}`)
 
-                node = m.testScene.createChild(testSuite.generatedNodeName)
+                nodeCreator = CreateObject("roSGNode", "RooibosNodeCreator")
+                node = nodeCreator@.CreateNode(testSuite.generatedNodeName, m.testScene)
                 port = CreateObject("roMessagePort")
                 node.observeField("rooibosTestResult", port)
                 ' Trigger test via observer so that thread ownership


### PR DESCRIPTION
Fix a bug where generated nodes are NOT created on the render thread (even though they end up on the render thread)

The addition of the node creator and calling it's function, forces the creation of the generated node to be done on render thread by rendezvous.

More context https://rokudevelopers.slack.com/archives/CD88K1TUJ/p1770128848757489 

Edit: ~~I will check ci test failures soon!~~ done

> BRIGHTSCRIPT: ERROR: roSGNode.ThreadInfo: RoSGNode instance of subtype Node is inaccessible from render thread
> I didn't think this was possible, but you can create a node that basically becomes "impossible" to access.
> Setup:
> You create some node of type MyNode from a Task. MyNode is a non-render node.
> In the Init() of MyNode, create some other non-render node, and keep a reference to it m.someOtherNode
> Transfer ownership of MyNode to render thread (by referencing it in a field of a SG node, like m.global.update({a: MyNode}, true))
> Now MyNode is on the render thread, but in MyNode's m.someOtherNode is still on Task thread
> Trying to access any of its functions (getFields(), threadInfo(), etc) will fail. 
> This was surprising because I thought a function like threadInfo() would be "thread safe" and you can call it in any case to figure out what to do next
> You need to first make it accessible to render thread first. If you don't have code that can do that in the m's, then it's just going to remain inaccessible