### PR TITLE
Update ropm to 0.11.7 and remove lodash override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "jsdoc": "^4.0.5",
                 "mocha": "^10.8.2",
                 "nyc": "^15.1.0",
-                "ropm": "^0.11.5",
+                "ropm": "^0.11.7",
                 "source-map-support": "^0.5.13",
                 "ts-node": "^10.7.0",
                 "typescript": "^4.7.2"
@@ -1415,26 +1415,6 @@
             "version": "1.68.0",
             "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
             "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
-        },
-        "node_modules/@xml-tools/ast": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-            "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-            "dev": true,
-            "dependencies": {
-                "@xml-tools/common": "^0.1.6",
-                "@xml-tools/parser": "^1.0.11",
-                "lodash": "4.17.21"
-            }
-        },
-        "node_modules/@xml-tools/common": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-            "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-            "dev": true,
-            "dependencies": {
-                "lodash": "4.17.21"
-            }
         },
         "node_modules/@xml-tools/parser": {
             "version": "1.0.11",
@@ -6655,22 +6635,21 @@
             "integrity": "sha512-Xl/8z4+WMeSHCG418Y9O49r/PQphwJ7efVmqlLoOvEg3EQ3ET//VHDQJa0YucuuTQurHfrLjXDj4foluhdHRSg=="
         },
         "node_modules/ropm": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.6.tgz",
-            "integrity": "sha512-4xVAAIGRsf3OqeJ/nTtvC3wqnyIf/lnluLQ0syEhBqdsQuikLhqstL/gi9e/86f/oORc5isoRC+/huvqtOoDWQ==",
+            "version": "0.11.7",
+            "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.7.tgz",
+            "integrity": "sha512-J+gazn70Dj87Jr4sqwmclwCA+baQSr7VstZL+ypDBl6IIOcpZEF8Ejtdc2XmuyUsDXbbQnlWUUl8rnqEkgmWow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rokucommunity/logger": "^0.3.11",
-                "@xml-tools/ast": "^5.0.5",
+                "@rokucommunity/logger": "^0.3.12",
                 "@xml-tools/parser": "1.0.10",
-                "brighterscript": "^0.72.1",
+                "brighterscript": "^0.72.2",
                 "del": "6.0.0",
                 "fs-extra": "9.1.0",
                 "glob-all": "3.2.1",
                 "latinize": "0.5.0",
                 "npm-packlist": "2.1.4",
-                "roku-deploy": "^3.17.2",
+                "roku-deploy": "^3.17.4",
                 "semver": "^7.6.3",
                 "yargs": "16.2.0"
             },
@@ -8450,7 +8429,7 @@
             "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.18.1"
+                "lodash": "^4.17.21"
             }
         },
         "@nodelib/fs.scandir": {
@@ -9016,26 +8995,6 @@
             "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
             "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
         },
-        "@xml-tools/ast": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-            "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-            "dev": true,
-            "requires": {
-                "@xml-tools/common": "^0.1.6",
-                "@xml-tools/parser": "^1.0.11",
-                "lodash": "^4.18.1"
-            }
-        },
-        "@xml-tools/common": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-            "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.18.1"
-            }
-        },
         "@xml-tools/parser": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
@@ -9588,7 +9547,7 @@
             "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
             "dev": true,
             "requires": {
-                "lodash": "^4.18.1"
+                "lodash": "^4.17.15"
             }
         },
         "chai": {
@@ -12625,7 +12584,7 @@
             "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.18.1"
+                "lodash": "^4.17.21"
             }
         },
         "resolve": {
@@ -12791,7 +12750,7 @@
                 "is-glob": "^4.0.3",
                 "jsonc-parser": "^2.3.0",
                 "jszip": "^3.6.0",
-                "lodash": "^4.18.1",
+                "lodash": "^4.17.21",
                 "micromatch": "^4.0.4",
                 "moment": "^2.29.1",
                 "parse-ms": "^2.1.0",
@@ -12903,21 +12862,20 @@
             "integrity": "sha512-Xl/8z4+WMeSHCG418Y9O49r/PQphwJ7efVmqlLoOvEg3EQ3ET//VHDQJa0YucuuTQurHfrLjXDj4foluhdHRSg=="
         },
         "ropm": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.6.tgz",
-            "integrity": "sha512-4xVAAIGRsf3OqeJ/nTtvC3wqnyIf/lnluLQ0syEhBqdsQuikLhqstL/gi9e/86f/oORc5isoRC+/huvqtOoDWQ==",
+            "version": "0.11.7",
+            "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.7.tgz",
+            "integrity": "sha512-J+gazn70Dj87Jr4sqwmclwCA+baQSr7VstZL+ypDBl6IIOcpZEF8Ejtdc2XmuyUsDXbbQnlWUUl8rnqEkgmWow==",
             "dev": true,
             "requires": {
-                "@rokucommunity/logger": "^0.3.11",
-                "@xml-tools/ast": "^5.0.5",
+                "@rokucommunity/logger": "^0.3.12",
                 "@xml-tools/parser": "1.0.10",
-                "brighterscript": "^0.72.1",
+                "brighterscript": "^0.72.2",
                 "del": "6.0.0",
                 "fs-extra": "9.1.0",
                 "glob-all": "3.2.1",
                 "latinize": "0.5.0",
                 "npm-packlist": "2.1.4",
-                "roku-deploy": "^3.17.2",
+                "roku-deploy": "^3.17.4",
                 "semver": "^7.6.3",
                 "yargs": "16.2.0"
             },

--- a/package.json
+++ b/package.json
@@ -54,13 +54,12 @@
         "jsdoc": "^4.0.5",
         "mocha": "^10.8.2",
         "nyc": "^15.1.0",
-        "ropm": "^0.11.5",
+        "ropm": "^0.11.7",
         "source-map-support": "^0.5.13",
         "ts-node": "^10.7.0",
         "typescript": "^4.7.2"
     },
     "overrides": {
-        "lodash": "^4.18.1",
         "serialize-javascript": "^7.0.5"
     },
     "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary
- Bump `ropm` from `^0.11.5` to `^0.11.7`. Upstream dropped `@xml-tools/ast`, which was pulling in the vulnerable bare `lodash` transitive dep.
- Remove the `lodash: ^4.18.1` override now that no dependency requires it. The `serialize-javascript` override is kept.