### PR TITLE
Make tests less brittle - removes full transpile string checks

### DIFF
--- a/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -4,147 +4,232 @@ import PluginInterface from 'brighterscript/dist/PluginInterface';
 import * as fsExtra from 'fs-extra';
 import { RooibosPlugin } from '../../plugin';
 import undent from 'undent';
+import { getContents } from '../../testHelpers.spec';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
 let _stagingFolderPath = s`${tmpPath}/staging`;
 
-describe('RooibosPlugin', () => {
+describe('CodeCoverageProcessor', () => {
     let program: Program;
     let builder: ProgramBuilder;
     let plugin: RooibosPlugin;
     let options;
 
-    function getContents(filename: string) {
-        let contents = fsExtra.readFileSync(s`${_stagingFolderPath}/${filename}`).toString();
-        return undent(contents);
-    }
+    beforeEach(() => {
+        plugin = new RooibosPlugin();
+        options = {
+            rootDir: _rootDir,
+            stagingFolderPath: _stagingFolderPath,
+            rooibos: {
+                isRecordingCodeCoverage: true,
+                coverageExcludedFiles: [
+                    '**/*.coverageExcluded.bs'
+                ]
+            },
+            allowBrighterScriptInBrightScript: true
+        };
+        fsExtra.ensureDirSync(_stagingFolderPath);
+        fsExtra.ensureDirSync(_rootDir);
 
-    describe('CodeCoverageProcessor', () => {
-        beforeEach(() => {
-            plugin = new RooibosPlugin();
-            options = {
-                rootDir: _rootDir,
-                stagingFolderPath: _stagingFolderPath,
-                rooibos: {
-                    isRecordingCodeCoverage: true,
-                    coverageExcludedFiles: [
-                        '**/*.coverageExcluded.bs'
-                    ]
-                },
-                allowBrighterScriptInBrightScript: true
-            };
-            fsExtra.ensureDirSync(_stagingFolderPath);
-            fsExtra.ensureDirSync(_rootDir);
+        builder = new ProgramBuilder();
+        builder.options = util.normalizeAndResolveConfig(options);
+        builder.program = new Program(builder.options);
+        program = builder.program;
+        program.logger = builder.logger;
+        builder.plugins = new PluginInterface([plugin], { logger: builder.logger });
+        program.plugins = new PluginInterface([plugin], { logger: builder.logger });
+        program.createSourceScope(); //ensure source scope is created
+        plugin.beforeProgramCreate(builder);
 
-            builder = new ProgramBuilder();
-            builder.options = util.normalizeAndResolveConfig(options);
-            builder.program = new Program(builder.options);
-            program = builder.program;
-            program.logger = builder.logger;
-            builder.plugins = new PluginInterface([plugin], { logger: builder.logger });
-            program.plugins = new PluginInterface([plugin], { logger: builder.logger });
-            program.createSourceScope(); //ensure source scope is created
-            plugin.beforeProgramCreate(builder);
+    });
+    afterEach(() => {
+        plugin.afterProgramCreate(program);
+        builder.dispose();
+        program.dispose();
+        fsExtra.removeSync(tmpPath);
+    });
 
-        });
-        afterEach(() => {
-            plugin.afterProgramCreate(program);
-            builder.dispose();
-            program.dispose();
-            fsExtra.removeSync(tmpPath);
-        });
+    describe('basic brs tests', () => {
 
-        describe('basic brs tests', () => {
-
-            // This test fails unless `allowBrighterScriptInBrightScript` is set to true when setting up the program
-            // in `beforeEach`. This is because the compiler normally skips processing .brs files and copies them as-is.
-            it('adds code coverage to a brs file', async () => {
-                program.setFile('source/code.brs', `
-                    function new(a1, a2)
-                        c = 0
-                        text = ""
-                        for i = 0 to 10
-                            text = text + "hello"
-                            c++
-                            c += 1
-                            if c = 2
-                                ? "is true"
-                            end if
-
-                            if c = 3
-                                ? "free"
-                            else
-                                ? "not free"
-                            end if
-                        end for
-                    end function
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    function new(a1, a2)
-                        RBS_CC_1_reportLine("2", 1)
-                        c = 0
-                        RBS_CC_1_reportLine("3", 1)
-                        text = ""
-                        RBS_CC_1_reportLine("4", 1): for i = 0 to 10
-                            RBS_CC_1_reportLine("5", 1)
-                            text = text + "hello"
-                            RBS_CC_1_reportLine("6", 1)
-                            c++
-                            RBS_CC_1_reportLine("7", 1)
-                            c += 1
-                            if RBS_CC_1_reportLine("8", 2) and (c = 2)
-                                RBS_CC_1_reportLine("8", 3)
-                                RBS_CC_1_reportLine("9", 1)
-                                ? "is true"
-                            end if
-                            if RBS_CC_1_reportLine("12", 2) and (c = 3)
-                                RBS_CC_1_reportLine("12", 3)
-                                RBS_CC_1_reportLine("13", 1)
-                                ? "free"
-                            else
-                                RBS_CC_1_reportLine("14", 3)
-                                RBS_CC_1_reportLine("15", 1)
-                                ? "not free"
-                            end if
-                        end for
-                    end function
-
-                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        _rbs_ccn = m._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            return true
+        // This test fails unless `allowBrighterScriptInBrightScript` is set to true when setting up the program
+        // in `beforeEach`. This is because the compiler normally skips processing .brs files and copies them as-is.
+        it('adds code coverage to a brs file', async () => {
+            program.setFile('source/code.brs', `
+                function new(a1, a2)
+                    c = 0
+                    text = ""
+                    for i = 0 to 10
+                        text = text + "hello"
+                        c++
+                        c += 1
+                        if c = 2
+                            ? "is true"
                         end if
-                        _rbs_ccn = m?.global?._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            m._rbs_ccn = _rbs_ccn
-                            return true
+
+                        if c = 3
+                            ? "free"
+                        else
+                            ? "not free"
                         end if
+                    end for
+                end function
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                function new(a1, a2)
+                    RBS_CC_1_reportLine("2", 1)
+                    c = 0
+                    RBS_CC_1_reportLine("3", 1)
+                    text = ""
+                    RBS_CC_1_reportLine("4", 1): for i = 0 to 10
+                        RBS_CC_1_reportLine("5", 1)
+                        text = text + "hello"
+                        RBS_CC_1_reportLine("6", 1)
+                        c++
+                        RBS_CC_1_reportLine("7", 1)
+                        c += 1
+                        if RBS_CC_1_reportLine("8", 2) and (c = 2)
+                            RBS_CC_1_reportLine("8", 3)
+                            RBS_CC_1_reportLine("9", 1)
+                            ? "is true"
+                        end if
+                        if RBS_CC_1_reportLine("12", 2) and (c = 3)
+                            RBS_CC_1_reportLine("12", 3)
+                            RBS_CC_1_reportLine("13", 1)
+                            ? "free"
+                        else
+                            RBS_CC_1_reportLine("14", 3)
+                            RBS_CC_1_reportLine("15", 1)
+                            ? "not free"
+                        end if
+                    end for
+                end function
+
+                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                    _rbs_ccn = m._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
                         return true
-                    end function
-                `);
-                expect(a).to.equal(b);
+                    end if
+                    _rbs_ccn = m?.global?._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        m._rbs_ccn = _rbs_ccn
+                        return true
+                    end if
+                    return true
+                end function
+            `);
+            expect(a).to.equal(b);
 
-            });
         });
-        describe('basic bs tests', () => {
+    });
 
-            it('adds code coverage to a bs file', async () => {
-                program.setFile('source/code.bs', `
+    describe('basic bs tests', () => {
+
+        it('adds code coverage to a bs file', async () => {
+            program.setFile('source/code.bs', `
+                function new(a1, a2)
+                c = 0
+                text = ""
+                    for i = 0 to 10
+                        text = text + "hello"
+                        c++
+                        c += 1
+                        if c = 2
+                            ? "is true"
+                        end if
+
+                        if c = 3
+                            ? "free"
+                        else
+                            ? "not free"
+                        end if
+                    end for
+                end function
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                function new(a1, a2)
+                    RBS_CC_1_reportLine("2", 1)
+                    c = 0
+                    RBS_CC_1_reportLine("3", 1)
+                    text = ""
+                    RBS_CC_1_reportLine("4", 1): for i = 0 to 10
+                        RBS_CC_1_reportLine("5", 1)
+                        text = text + "hello"
+                        RBS_CC_1_reportLine("6", 1)
+                        c++
+                        RBS_CC_1_reportLine("7", 1)
+                        c += 1
+                        if RBS_CC_1_reportLine("8", 2) and (c = 2)
+                            RBS_CC_1_reportLine("8", 3)
+                            RBS_CC_1_reportLine("9", 1)
+                            ? "is true"
+                        end if
+                        if RBS_CC_1_reportLine("12", 2) and (c = 3)
+                            RBS_CC_1_reportLine("12", 3)
+                            RBS_CC_1_reportLine("13", 1)
+                            ? "free"
+                        else
+                            RBS_CC_1_reportLine("14", 3)
+                            RBS_CC_1_reportLine("15", 1)
+                            ? "not free"
+                        end if
+                    end for
+                end function
+
+                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                    _rbs_ccn = m._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        return true
+                    end if
+                    _rbs_ccn = m?.global?._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        m._rbs_ccn = _rbs_ccn
+                        return true
+                    end if
+                    return true
+                end function
+            `);
+            expect(a).to.equal(b);
+
+        });
+    });
+
+    describe('basic tests', () => {
+
+        it('adds code coverage to a bs file', async () => {
+            program.setFile('source/code.bs', `
+                class BasicClass
+                    private field1
+                    public field2
+
                     function new(a1, a2)
                     c = 0
                     text = ""
@@ -162,106 +247,17 @@ describe('RooibosPlugin', () => {
                                 ? "not free"
                             end if
                         end for
-                    end function
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    function new(a1, a2)
-                        RBS_CC_1_reportLine("2", 1)
-                        c = 0
-                        RBS_CC_1_reportLine("3", 1)
-                        text = ""
-                        RBS_CC_1_reportLine("4", 1): for i = 0 to 10
-                            RBS_CC_1_reportLine("5", 1)
-                            text = text + "hello"
-                            RBS_CC_1_reportLine("6", 1)
-                            c++
-                            RBS_CC_1_reportLine("7", 1)
-                            c += 1
-                            if RBS_CC_1_reportLine("8", 2) and (c = 2)
-                                RBS_CC_1_reportLine("8", 3)
-                                RBS_CC_1_reportLine("9", 1)
-                                ? "is true"
-                            end if
-                            if RBS_CC_1_reportLine("12", 2) and (c = 3)
-                                RBS_CC_1_reportLine("12", 3)
-                                RBS_CC_1_reportLine("13", 1)
-                                ? "free"
-                            else
-                                RBS_CC_1_reportLine("14", 3)
-                                RBS_CC_1_reportLine("15", 1)
-                                ? "not free"
-                            end if
-                        end for
+
                     end function
 
-                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        _rbs_ccn = m._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            return true
-                        end if
-                        _rbs_ccn = m?.global?._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            m._rbs_ccn = _rbs_ccn
-                            return true
-                        end if
-                        return true
-                    end function
-                `);
-                expect(a).to.equal(b);
 
-            });
-        });
-
-        describe('basic tests', () => {
-
-            it('adds code coverage to a bs file', async () => {
-                program.setFile('source/code.bs', `
-                    class BasicClass
-                        private field1
-                        public field2
-
-                        function new(a1, a2)
-                        c = 0
-                        text = ""
-                            for i = 0 to 10
-                                text = text + "hello"
-                                c++
-                                c += 1
-                                if c = 2
-                                    ? "is true"
-                                end if
-
-                                if c = 3
-                                    ? "free"
-                                else
-                                    ? "not free"
-                                end if
-                            end for
-
-                        end function
-
-
-                    end class
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
+                end class
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
                 function __BasicClass_method_new(a1, a2)
                     m.field1 = invalid
                     m.field2 = invalid
@@ -325,174 +321,11 @@ describe('RooibosPlugin', () => {
                     end if
                     return true
                 end function
-                `);
-                expect(a).to.equal(b);
-            });
-
-            it.skip('correctly transpiles some statements', async () => {
-                const source = `sub foo()
-                    x = function(y)
-                        if (true) then
-                            return 1
-                        end if
-                        return 0
-                    end function
-                end sub`;
-
-                program.setFile('source/code.bs', source);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    sub foo()
-                        RBS_CC_1_reportLine("1", 1)
-                        x = function(y)
-                            if RBS_CC_1_reportLine("2", 2) and ((true)) then
-                                RBS_CC_1_reportLine("2", 3)
-                                RBS_CC_1_reportLine("3", 1)
-                                return 1
-                            end if
-                            RBS_CC_1_reportLine("5", 1)
-                            return 0
-                        end function
-                    end sub
-
-                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        _rbs_ccn = m._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            return true
-                        end if
-                        _rbs_ccn = m?.global?._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            m._rbs_ccn = _rbs_ccn
-                            return true
-                        end if
-                        return true
-                    end function
-                `);
-
-                expect(a).to.equal(b);
-            });
-
-            it('correctly transpiles some statements', async () => {
-                const source = `
-                    sub foo(action as string)
-                        if action = "action1" then
-                            print "action1"
-                        else if action = "action2" or action = "action2" then
-                            print "action2"
-                        else if action = "action3" then
-                            print "action3"
-                        else if action = "action4" then
-                        else if action = "action5" then
-                            print "action5"
-                        else if action = "action6" then
-                            print "action6"
-                        else if action = "action7" then
-                            print "action7"
-                        else if action = "action8" then
-                            print "action8"
-                        else if action = "action9" then
-                            print "action9"
-                        else if action = "action10" then
-                            print "action10"
-                        else
-                        end if
-                    end sub
-                `;
-
-                program.setFile('source/code.bs', source);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    sub foo(action as string)
-                        if RBS_CC_1_reportLine("2", 2) and (action = "action1") then
-                            RBS_CC_1_reportLine("2", 3)
-                            RBS_CC_1_reportLine("3", 1)
-                            print "action1"
-                        else if RBS_CC_1_reportLine("4", 2) and (action = "action2" or action = "action2") then
-                            RBS_CC_1_reportLine("4", 3)
-                            RBS_CC_1_reportLine("5", 1)
-                            print "action2"
-                        else if RBS_CC_1_reportLine("6", 2) and (action = "action3") then
-                            RBS_CC_1_reportLine("6", 3)
-                            RBS_CC_1_reportLine("7", 1)
-                            print "action3"
-                        else if RBS_CC_1_reportLine("8", 2) and (action = "action4") then
-                            RBS_CC_1_reportLine("8", 3)
-                        else if RBS_CC_1_reportLine("9", 2) and (action = "action5") then
-                            RBS_CC_1_reportLine("9", 3)
-                            RBS_CC_1_reportLine("10", 1)
-                            print "action5"
-                        else if RBS_CC_1_reportLine("11", 2) and (action = "action6") then
-                            RBS_CC_1_reportLine("11", 3)
-                            RBS_CC_1_reportLine("12", 1)
-                            print "action6"
-                        else if RBS_CC_1_reportLine("13", 2) and (action = "action7") then
-                            RBS_CC_1_reportLine("13", 3)
-                            RBS_CC_1_reportLine("14", 1)
-                            print "action7"
-                        else if RBS_CC_1_reportLine("15", 2) and (action = "action8") then
-                            RBS_CC_1_reportLine("15", 3)
-                            RBS_CC_1_reportLine("16", 1)
-                            print "action8"
-                        else if RBS_CC_1_reportLine("17", 2) and (action = "action9") then
-                            RBS_CC_1_reportLine("17", 3)
-                            RBS_CC_1_reportLine("18", 1)
-                            print "action9"
-                        else if RBS_CC_1_reportLine("19", 2) and (action = "action10") then
-                            RBS_CC_1_reportLine("19", 3)
-                            RBS_CC_1_reportLine("20", 1)
-                            print "action10"
-                        else
-                            RBS_CC_1_reportLine("21", 3)
-                        end if
-                    end sub
-
-                    function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                        _rbs_ccn = m._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            return true
-                        end if
-                        _rbs_ccn = m?.global?._rbs_ccn
-                        if _rbs_ccn <> invalid
-                            _rbs_ccn.entry = {
-                                "f": "1"
-                                "l": lineNumber
-                                "r": reportType
-                            }
-                            m._rbs_ccn = _rbs_ccn
-                            return true
-                        end if
-                        return true
-                    end function
-                `);
-
-                expect(a).to.equal(b);
-            });
+            `);
+            expect(a).to.equal(b);
         });
 
-        it('excludes files from coverage', async () => {
+        it.skip('correctly transpiles some statements', async () => {
             const source = `sub foo()
                 x = function(y)
                     if (true) then
@@ -502,24 +335,186 @@ describe('RooibosPlugin', () => {
                 end function
             end sub`;
 
-            program.setFile('source/code.coverageExcluded.bs', source);
+            program.setFile('source/code.bs', source);
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             await builder.transpile();
 
-            let a = getContents('source/code.coverageExcluded.brs');
+            let a = getContents('source/code.brs');
             let b = undent(`
                 sub foo()
+                    RBS_CC_1_reportLine("1", 1)
                     x = function(y)
-                        if (true) then
+                        if RBS_CC_1_reportLine("2", 2) and ((true)) then
+                            RBS_CC_1_reportLine("2", 3)
+                            RBS_CC_1_reportLine("3", 1)
                             return 1
                         end if
+                        RBS_CC_1_reportLine("5", 1)
                         return 0
                     end function
                 end sub
+
+                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                    _rbs_ccn = m._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        return true
+                    end if
+                    _rbs_ccn = m?.global?._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        m._rbs_ccn = _rbs_ccn
+                        return true
+                    end if
+                    return true
+                end function
             `);
 
             expect(a).to.equal(b);
         });
+
+        it('correctly transpiles some statements', async () => {
+            const source = `
+                sub foo(action as string)
+                    if action = "action1" then
+                        print "action1"
+                    else if action = "action2" or action = "action2" then
+                        print "action2"
+                    else if action = "action3" then
+                        print "action3"
+                    else if action = "action4" then
+                    else if action = "action5" then
+                        print "action5"
+                    else if action = "action6" then
+                        print "action6"
+                    else if action = "action7" then
+                        print "action7"
+                    else if action = "action8" then
+                        print "action8"
+                    else if action = "action9" then
+                        print "action9"
+                    else if action = "action10" then
+                        print "action10"
+                    else
+                    end if
+                end sub
+            `;
+
+            program.setFile('source/code.bs', source);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                sub foo(action as string)
+                    if RBS_CC_1_reportLine("2", 2) and (action = "action1") then
+                        RBS_CC_1_reportLine("2", 3)
+                        RBS_CC_1_reportLine("3", 1)
+                        print "action1"
+                    else if RBS_CC_1_reportLine("4", 2) and (action = "action2" or action = "action2") then
+                        RBS_CC_1_reportLine("4", 3)
+                        RBS_CC_1_reportLine("5", 1)
+                        print "action2"
+                    else if RBS_CC_1_reportLine("6", 2) and (action = "action3") then
+                        RBS_CC_1_reportLine("6", 3)
+                        RBS_CC_1_reportLine("7", 1)
+                        print "action3"
+                    else if RBS_CC_1_reportLine("8", 2) and (action = "action4") then
+                        RBS_CC_1_reportLine("8", 3)
+                    else if RBS_CC_1_reportLine("9", 2) and (action = "action5") then
+                        RBS_CC_1_reportLine("9", 3)
+                        RBS_CC_1_reportLine("10", 1)
+                        print "action5"
+                    else if RBS_CC_1_reportLine("11", 2) and (action = "action6") then
+                        RBS_CC_1_reportLine("11", 3)
+                        RBS_CC_1_reportLine("12", 1)
+                        print "action6"
+                    else if RBS_CC_1_reportLine("13", 2) and (action = "action7") then
+                        RBS_CC_1_reportLine("13", 3)
+                        RBS_CC_1_reportLine("14", 1)
+                        print "action7"
+                    else if RBS_CC_1_reportLine("15", 2) and (action = "action8") then
+                        RBS_CC_1_reportLine("15", 3)
+                        RBS_CC_1_reportLine("16", 1)
+                        print "action8"
+                    else if RBS_CC_1_reportLine("17", 2) and (action = "action9") then
+                        RBS_CC_1_reportLine("17", 3)
+                        RBS_CC_1_reportLine("18", 1)
+                        print "action9"
+                    else if RBS_CC_1_reportLine("19", 2) and (action = "action10") then
+                        RBS_CC_1_reportLine("19", 3)
+                        RBS_CC_1_reportLine("20", 1)
+                        print "action10"
+                    else
+                        RBS_CC_1_reportLine("21", 3)
+                    end if
+                end sub
+
+                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
+                    _rbs_ccn = m._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        return true
+                    end if
+                    _rbs_ccn = m?.global?._rbs_ccn
+                    if _rbs_ccn <> invalid
+                        _rbs_ccn.entry = {
+                            "f": "1"
+                            "l": lineNumber
+                            "r": reportType
+                        }
+                        m._rbs_ccn = _rbs_ccn
+                        return true
+                    end if
+                    return true
+                end function
+            `);
+
+            expect(a).to.equal(b);
+        });
+    });
+
+    it('excludes files from coverage', async () => {
+        const source = `sub foo()
+            x = function(y)
+                if (true) then
+                    return 1
+                end if
+                return 0
+            end function
+        end sub`;
+
+        program.setFile('source/code.coverageExcluded.bs', source);
+        program.validate();
+        expect(program.getDiagnostics()).to.be.empty;
+        await builder.transpile();
+
+        let a = getContents('source/code.coverageExcluded.brs');
+        let b = undent(`
+            sub foo()
+                x = function(y)
+                    if (true) then
+                        return 1
+                    end if
+                    return 0
+                end function
+            end sub
+        `);
+
+        expect(a).to.equal(b);
     });
 });

--- a/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -253,8 +253,8 @@ describe('CodeCoverageProcessor', () => {
                     public field2
 
                     function new(a1, a2)
-                    c = 0
-                    text = ""
+                        c = 0
+                        text = ""
                         for i = 0 to 10
                             text = text + "hello"
                             c++
@@ -280,7 +280,7 @@ describe('CodeCoverageProcessor', () => {
             await builder.transpile();
             const transpiledSource = getContents('source/code.brs');
             const funcAst = getFunctionAstNode(transpiledSource, '__BasicClass_method_new');
-            expectReportLineFunctionCalls(funcAst.func.body, 'RBS_CC_1_reportLine', { currentLine: 2 });
+            expectReportLineFunctionCalls(funcAst.func.body, 'RBS_CC_1_reportLine', { currentLine: 6 });
         });
 
         it.skip('correctly transpiles some statements', async () => {
@@ -483,8 +483,8 @@ function expectReportLineFunctionCalls(ast: { statements: Statement[] }, reportL
                     expectReportLineFunctionCalls(stmt.elseBranch, reportLineFuncName, opts);
                 }
             }
-        } else if (!isExpressionStatement(stmt)) {
-            checkForReportLine((previousStmt as ExpressionStatement).expression, opts, CodeCoverageLineType.code);
+        } else if (!isExpressionStatement(stmt) && isExpressionStatement(previousStmt)) {
+            checkForReportLine(previousStmt.expression, opts, CodeCoverageLineType.code);
             opts.currentLine++;
             if (isIfStatement(stmt)) {
                 expectReportLineFunctionCalls(stmt.thenBranch, reportLineFuncName, opts);

--- a/src/lib/rooibos/CodeCoverageProcessor.spec.ts
+++ b/src/lib/rooibos/CodeCoverageProcessor.spec.ts
@@ -1,10 +1,12 @@
-import { Program, ProgramBuilder, util, standardizePath as s } from 'brighterscript';
+import { Program, ProgramBuilder, util, standardizePath as s, isExpressionStatement, isCallExpression, isIfStatement } from 'brighterscript';
+import type { BinaryExpression, Expression, ExpressionStatement, LiteralExpression, Statement, VariableExpression } from 'brighterscript';
 import { expect } from 'chai';
 import PluginInterface from 'brighterscript/dist/PluginInterface';
 import * as fsExtra from 'fs-extra';
 import { RooibosPlugin } from '../../plugin';
 import undent from 'undent';
-import { getContents } from '../../testHelpers.spec';
+import { expectFunctionContents, expectZeroDiagnostics, getContents, getFunctionAstNode } from '../../testHelpers.spec';
+import { CodeCoverageLineType } from './CodeCoverageType';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
@@ -78,72 +80,119 @@ describe('CodeCoverageProcessor', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             await builder.transpile();
-            let a = getContents('source/code.brs');
-            let b = undent(`
-                function new(a1, a2)
-                    RBS_CC_1_reportLine("2", 1)
-                    c = 0
-                    RBS_CC_1_reportLine("3", 1)
-                    text = ""
-                    RBS_CC_1_reportLine("4", 1): for i = 0 to 10
-                        RBS_CC_1_reportLine("5", 1)
-                        text = text + "hello"
-                        RBS_CC_1_reportLine("6", 1)
-                        c++
-                        RBS_CC_1_reportLine("7", 1)
-                        c += 1
-                        if RBS_CC_1_reportLine("8", 2) and (c = 2)
-                            RBS_CC_1_reportLine("8", 3)
-                            RBS_CC_1_reportLine("9", 1)
-                            ? "is true"
-                        end if
-                        if RBS_CC_1_reportLine("12", 2) and (c = 3)
-                            RBS_CC_1_reportLine("12", 3)
-                            RBS_CC_1_reportLine("13", 1)
-                            ? "free"
-                        else
-                            RBS_CC_1_reportLine("14", 3)
-                            RBS_CC_1_reportLine("15", 1)
-                            ? "not free"
-                        end if
-                    end for
-                end function
-
-                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                    _rbs_ccn = m._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        return true
+            const transpiledContents = getContents('source/code.brs');
+            expectFunctionContents(transpiledContents, 'new', `
+                RBS_CC_1_reportLine("2", 1)
+                c = 0
+                RBS_CC_1_reportLine("3", 1)
+                text = ""
+                RBS_CC_1_reportLine("4", 1): for i = 0 to 10
+                    RBS_CC_1_reportLine("5", 1)
+                    text = text + "hello"
+                    RBS_CC_1_reportLine("6", 1)
+                    c++
+                    RBS_CC_1_reportLine("7", 1)
+                    c += 1
+                    if RBS_CC_1_reportLine("8", 2) and (c = 2)
+                        RBS_CC_1_reportLine("8", 3)
+                        RBS_CC_1_reportLine("9", 1)
+                        ? "is true"
                     end if
-                    _rbs_ccn = m?.global?._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        m._rbs_ccn = _rbs_ccn
-                        return true
+                    if RBS_CC_1_reportLine("12", 2) and (c = 3)
+                        RBS_CC_1_reportLine("12", 3)
+                        RBS_CC_1_reportLine("13", 1)
+                        ? "free"
+                    else
+                        RBS_CC_1_reportLine("14", 3)
+                        RBS_CC_1_reportLine("15", 1)
+                        ? "not free"
                     end if
-                    return true
-                end function
+                end for
             `);
-            expect(a).to.equal(b);
-
+            const reportLineFunction = getFunctionAstNode(transpiledContents, 'RBS_CC_1_reportLine');
+            expect(reportLineFunction).to.exist;
         });
     });
 
     describe('basic bs tests', () => {
+        it('adds the code coverage function to a file', async () => {
+            program.setFile('source/code.bs', `
+                function foo()
+                    x = 2
+                    print x
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            await builder.transpile();
+            const transpiledSource = getContents('source/code.brs');
+            const funcAst = getFunctionAstNode(transpiledSource, 'RBS_CC_1_reportLine');
+            expect(funcAst).to.exist;
+            expect(funcAst.func.parameters.map(p => p.name.text)).to.deep.equal(['lineNumber', 'reportType']);
+            expectFunctionContents(transpiledSource, 'RBS_CC_1_reportLine', `
+                _rbs_ccn = m._rbs_ccn
+                if _rbs_ccn <> invalid
+                    _rbs_ccn.entry = {
+                        "f": "1"
+                        "l": lineNumber
+                        "r": reportType
+                    }
+                    return true
+                end if
+                _rbs_ccn = m?.global?._rbs_ccn
+                if _rbs_ccn <> invalid
+                    _rbs_ccn.entry = {
+                        "f": "1"
+                        "l": lineNumber
+                        "r": reportType
+                    }
+                    m._rbs_ccn = _rbs_ccn
+                    return true
+                end if
+                return true
+            `);
+        });
+
+        it('adds code coverage reportLine statements to a function', async () => {
+            program.setFile('source/code.bs', `
+                function foo()
+                    x = 2
+                    print x
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            await builder.transpile();
+            const funcAst = getFunctionAstNode(getContents('source/code.brs'), 'foo');
+            expectReportLineFunctionCalls(funcAst.func.body, 'RBS_CC_1_reportLine', { currentLine: 2 });
+        });
+
+
+        it('adds code coverage reportLine statements to a function with if statements', async () => {
+            program.setFile('source/code.bs', `
+                function foo(x)
+                    if x = 1
+                       print "one"
+                    else if x = 2
+                       print "two"
+                    else
+                       print "other"
+                    end if
+                end function
+            `);
+            program.validate();
+            expectZeroDiagnostics(program);
+            await builder.transpile();
+            const transpiledSource = getContents('source/code.brs');
+            const funcAst = getFunctionAstNode(transpiledSource, 'foo');
+            expectReportLineFunctionCalls(funcAst.func.body, 'RBS_CC_1_reportLine', { currentLine: 2 });
+        });
 
         it('adds code coverage to a bs file', async () => {
             program.setFile('source/code.bs', `
                 function new(a1, a2)
-                c = 0
-                text = ""
+                    c = 0
+                    text = ""
                     for i = 0 to 10
                         text = text + "hello"
                         c++
@@ -163,68 +212,41 @@ describe('CodeCoverageProcessor', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             await builder.transpile();
-            let a = getContents('source/code.brs');
-            let b = undent(`
-                function new(a1, a2)
-                    RBS_CC_1_reportLine("2", 1)
-                    c = 0
-                    RBS_CC_1_reportLine("3", 1)
-                    text = ""
-                    RBS_CC_1_reportLine("4", 1): for i = 0 to 10
-                        RBS_CC_1_reportLine("5", 1)
-                        text = text + "hello"
-                        RBS_CC_1_reportLine("6", 1)
-                        c++
-                        RBS_CC_1_reportLine("7", 1)
-                        c += 1
-                        if RBS_CC_1_reportLine("8", 2) and (c = 2)
-                            RBS_CC_1_reportLine("8", 3)
-                            RBS_CC_1_reportLine("9", 1)
-                            ? "is true"
-                        end if
-                        if RBS_CC_1_reportLine("12", 2) and (c = 3)
-                            RBS_CC_1_reportLine("12", 3)
-                            RBS_CC_1_reportLine("13", 1)
-                            ? "free"
-                        else
-                            RBS_CC_1_reportLine("14", 3)
-                            RBS_CC_1_reportLine("15", 1)
-                            ? "not free"
-                        end if
-                    end for
-                end function
-
-                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                    _rbs_ccn = m._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        return true
+            let transpiledContents = getContents('source/code.brs');
+            expectFunctionContents(transpiledContents, 'new', `
+                RBS_CC_1_reportLine("2", 1)
+                c = 0
+                RBS_CC_1_reportLine("3", 1)
+                text = ""
+                RBS_CC_1_reportLine("4", 1): for i = 0 to 10
+                    RBS_CC_1_reportLine("5", 1)
+                    text = text + "hello"
+                    RBS_CC_1_reportLine("6", 1)
+                    c++
+                    RBS_CC_1_reportLine("7", 1)
+                    c += 1
+                    if RBS_CC_1_reportLine("8", 2) and (c = 2)
+                        RBS_CC_1_reportLine("8", 3)
+                        RBS_CC_1_reportLine("9", 1)
+                        ? "is true"
                     end if
-                    _rbs_ccn = m?.global?._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        m._rbs_ccn = _rbs_ccn
-                        return true
+                    if RBS_CC_1_reportLine("12", 2) and (c = 3)
+                        RBS_CC_1_reportLine("12", 3)
+                        RBS_CC_1_reportLine("13", 1)
+                        ? "free"
+                    else
+                        RBS_CC_1_reportLine("14", 3)
+                        RBS_CC_1_reportLine("15", 1)
+                        ? "not free"
                     end if
-                    return true
-                end function
+                end for
             `);
-            expect(a).to.equal(b);
-
         });
     });
 
     describe('basic tests', () => {
 
-        it('adds code coverage to a bs file', async () => {
+        it('adds code coverage to a bs file with a class', async () => {
             program.setFile('source/code.bs', `
                 class BasicClass
                     private field1
@@ -256,73 +278,9 @@ describe('CodeCoverageProcessor', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             await builder.transpile();
-            let a = getContents('source/code.brs');
-            let b = undent(`
-                function __BasicClass_method_new(a1, a2)
-                    m.field1 = invalid
-                    m.field2 = invalid
-                    RBS_CC_1_reportLine("6", 1)
-                    c = 0
-                    RBS_CC_1_reportLine("7", 1)
-                    text = ""
-                    RBS_CC_1_reportLine("8", 1): for i = 0 to 10
-                        RBS_CC_1_reportLine("9", 1)
-                        text = text + "hello"
-                        RBS_CC_1_reportLine("10", 1)
-                        c++
-                        RBS_CC_1_reportLine("11", 1)
-                        c += 1
-                        if RBS_CC_1_reportLine("12", 2) and (c = 2)
-                            RBS_CC_1_reportLine("12", 3)
-                            RBS_CC_1_reportLine("13", 1)
-                            ? "is true"
-                        end if
-                        if RBS_CC_1_reportLine("16", 2) and (c = 3)
-                            RBS_CC_1_reportLine("16", 3)
-                            RBS_CC_1_reportLine("17", 1)
-                            ? "free"
-                        else
-                            RBS_CC_1_reportLine("18", 3)
-                            RBS_CC_1_reportLine("19", 1)
-                            ? "not free"
-                        end if
-                    end for
-                end function
-                function __BasicClass_builder()
-                    instance = {}
-                    instance.new = __BasicClass_method_new
-                    return instance
-                end function
-                function BasicClass(a1, a2)
-                    instance = __BasicClass_builder()
-                    instance.new(a1, a2)
-                    return instance
-                end function
-
-                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                    _rbs_ccn = m._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        return true
-                    end if
-                    _rbs_ccn = m?.global?._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        m._rbs_ccn = _rbs_ccn
-                        return true
-                    end if
-                    return true
-                end function
-            `);
-            expect(a).to.equal(b);
+            const transpiledSource = getContents('source/code.brs');
+            const funcAst = getFunctionAstNode(transpiledSource, '__BasicClass_method_new');
+            expectReportLineFunctionCalls(funcAst.func.body, 'RBS_CC_1_reportLine', { currentLine: 2 });
         });
 
         it.skip('correctly transpiles some statements', async () => {
@@ -339,47 +297,18 @@ describe('CodeCoverageProcessor', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             await builder.transpile();
-
-            let a = getContents('source/code.brs');
-            let b = undent(`
-                sub foo()
-                    RBS_CC_1_reportLine("1", 1)
-                    x = function(y)
-                        if RBS_CC_1_reportLine("2", 2) and ((true)) then
-                            RBS_CC_1_reportLine("2", 3)
-                            RBS_CC_1_reportLine("3", 1)
-                            return 1
-                        end if
-                        RBS_CC_1_reportLine("5", 1)
-                        return 0
-                    end function
-                end sub
-
-                function RBS_CC_1_reportLine(lineNumber, reportType = 1)
-                    _rbs_ccn = m._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        return true
+            expectFunctionContents(getContents('source/code.brs'), 'foo', `
+                RBS_CC_1_reportLine("1", 1)
+                x = function(y)
+                    if RBS_CC_1_reportLine("2", 2) and ((true)) then
+                        RBS_CC_1_reportLine("2", 3)
+                        RBS_CC_1_reportLine("3", 1)
+                        return 1
                     end if
-                    _rbs_ccn = m?.global?._rbs_ccn
-                    if _rbs_ccn <> invalid
-                        _rbs_ccn.entry = {
-                            "f": "1"
-                            "l": lineNumber
-                            "r": reportType
-                        }
-                        m._rbs_ccn = _rbs_ccn
-                        return true
-                    end if
-                    return true
+                    RBS_CC_1_reportLine("5", 1)
+                    return 0
                 end function
             `);
-
-            expect(a).to.equal(b);
         });
 
         it('correctly transpiles some statements', async () => {
@@ -518,3 +447,50 @@ describe('CodeCoverageProcessor', () => {
         expect(a).to.equal(b);
     });
 });
+
+
+function expectReportLineFunctionCalls(ast: { statements: Statement[] }, reportLineFuncName: string, opts: { currentLine: number }) {
+    let previousStmt: Statement;
+
+    function checkForReportLine(expr: Expression, opts: { currentLine: number }, coverageType: CodeCoverageLineType) {
+        expect(isCallExpression(expr), `Expected statement ${opts.currentLine} to be an call expression`).to.be.true;
+        if (isCallExpression(expr)) {
+            const callExpr = expr;
+            let callee = (callExpr.callee as VariableExpression).name;
+            expect(callee.text, `Expected callee to be "${reportLineFuncName}"`).to.equal(reportLineFuncName);
+            expect(callExpr.args.length).to.be.equal(2);
+            let lineArg = callExpr.args[0];
+            let reportTypeArg = callExpr.args[1];
+            expect((lineArg as LiteralExpression).token.text, `Expected line argument to be "${opts.currentLine.toString()}"`).to.equal(`"${opts.currentLine.toString()}"`);
+            expect((reportTypeArg as LiteralExpression).token.text, `Expected report type argument to be "${coverageType}"`).to.equal(`${coverageType}`);
+        }
+    }
+
+    for (const stmt of ast.statements) {
+        if (isIfStatement(stmt)) {
+            checkForReportLine((stmt.condition as BinaryExpression).left, opts, CodeCoverageLineType.condition);
+            if (stmt.thenBranch) {
+                checkForReportLine((stmt.thenBranch.statements[0] as ExpressionStatement).expression, opts, CodeCoverageLineType.branch);
+                opts.currentLine++;
+                expectReportLineFunctionCalls(stmt.thenBranch, reportLineFuncName, opts);
+            }
+            if (stmt.elseBranch) {
+                if (isIfStatement(stmt.elseBranch)) {
+                    expectReportLineFunctionCalls({ statements: [stmt.elseBranch] }, reportLineFuncName, opts);
+                } else {
+                    checkForReportLine((stmt.elseBranch.statements[0] as ExpressionStatement).expression, opts, CodeCoverageLineType.branch);
+                    opts.currentLine++;
+                    expectReportLineFunctionCalls(stmt.elseBranch, reportLineFuncName, opts);
+                }
+            }
+        } else if (!isExpressionStatement(stmt)) {
+            checkForReportLine((previousStmt as ExpressionStatement).expression, opts, CodeCoverageLineType.code);
+            opts.currentLine++;
+            if (isIfStatement(stmt)) {
+                expectReportLineFunctionCalls(stmt.thenBranch, reportLineFuncName, opts);
+            }
+        }
+        previousStmt = stmt;
+
+    }
+}

--- a/src/lib/rooibos/CodeCoverageProcessor.ts
+++ b/src/lib/rooibos/CodeCoverageProcessor.ts
@@ -40,7 +40,7 @@ export class CodeCoverageProcessor {
         this.fileFactory = fileFactory;
         try {
         } catch (e) {
-            console.log('Error:', e.stack);
+            console.log('Error:', (e as Error).stack);
         }
     }
 

--- a/src/lib/rooibos/MockUtil.spec.ts
+++ b/src/lib/rooibos/MockUtil.spec.ts
@@ -4,6 +4,7 @@ import PluginInterface from 'brighterscript/dist/PluginInterface';
 import * as fsExtra from 'fs-extra';
 import { RooibosPlugin } from '../../plugin';
 import undent from 'undent';
+import { getContents } from '../../testHelpers.spec';
 
 let tmpPath = s`${process.cwd()}/.tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
@@ -15,344 +16,338 @@ describe('MockUtil', () => {
     let plugin: RooibosPlugin;
     let options;
 
-    function getContents(filename: string) {
-        let contents = fsExtra.readFileSync(s`${_stagingFolderPath}/${filename}`).toString();
-        return contents;
-    }
+    beforeEach(() => {
+        plugin = new RooibosPlugin();
+        options = {
+            rootDir: _rootDir,
+            stagingFolderPath: _stagingFolderPath,
+            rooibos: {
+                isGlobalMethodMockingEnabled: true,
+                globalMethodMockingExcludedFiles: [
+                    '**/*.coverageExcluded.bs'
+                ],
+                isGlobalMethodMockingEfficientMode: false
+            },
+            allowBrighterScriptInBrightScript: true
+        };
+        fsExtra.ensureDirSync(_stagingFolderPath);
+        fsExtra.ensureDirSync(_rootDir);
 
-    describe('MockUtil', () => {
-        beforeEach(() => {
-            plugin = new RooibosPlugin();
-            options = {
-                rootDir: _rootDir,
-                stagingFolderPath: _stagingFolderPath,
-                rooibos: {
-                    isGlobalMethodMockingEnabled: true,
-                    globalMethodMockingExcludedFiles: [
-                        '**/*.coverageExcluded.bs'
-                    ],
-                    isGlobalMethodMockingEfficientMode: false
-                },
-                allowBrighterScriptInBrightScript: true
-            };
-            fsExtra.ensureDirSync(_stagingFolderPath);
-            fsExtra.ensureDirSync(_rootDir);
+        builder = new ProgramBuilder();
+        builder.options = util.normalizeAndResolveConfig(options);
+        builder.program = new Program(builder.options);
+        program = builder.program;
+        program.logger = builder.logger;
+        builder.plugins = new PluginInterface([plugin], { logger: builder.logger });
+        program.plugins = new PluginInterface([plugin], { logger: builder.logger });
+        program.createSourceScope(); //ensure source scope is created
+        plugin.beforeProgramCreate(builder);
 
-            builder = new ProgramBuilder();
-            builder.options = util.normalizeAndResolveConfig(options);
-            builder.program = new Program(builder.options);
-            program = builder.program;
-            program.logger = builder.logger;
-            builder.plugins = new PluginInterface([plugin], { logger: builder.logger });
-            program.plugins = new PluginInterface([plugin], { logger: builder.logger });
-            program.createSourceScope(); //ensure source scope is created
-            plugin.beforeProgramCreate(builder);
+    });
+    afterEach(() => {
+        plugin.afterProgramCreate(program);
+        builder.dispose();
+        program.dispose();
+        fsExtra.removeSync(tmpPath);
+    });
+
+    describe('basic brs tests', () => {
+
+        // This test fails unless `allowBrighterScriptInBrightScript` is set to true when setting up the program
+        // in `beforeEach`. This is because the compiler normally skips processing .brs files and copies them as-is.
+        it('adds util code to a brs file', async () => {
+            program.setFile('source/code.brs', `
+                    function sayHello(a1, a2)
+                        print "hello"
+                    end function
+                `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                function sayHello(a1, a2)
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback(a1, a2)
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.sayhello
+                        __stubOrMockResult = __stubFunction(a1, a2)
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
+                        value = __stubs_globalAa.__globalStubs.sayhello
+                        return value
+                    end if
+                    print "hello"
+                end function
+
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
 
         });
-        afterEach(() => {
-            plugin.afterProgramCreate(program);
-            builder.dispose();
-            program.dispose();
-            fsExtra.removeSync(tmpPath);
+    });
+    describe('basic bs tests', () => {
+
+        it('enables mocking on global functions', async () => {
+            program.setFile('source/code.bs', `
+                function sayHello(a1, a2)
+                    print "hello"
+                end function
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                function sayHello(a1, a2)
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback(a1, a2)
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.sayhello
+                        __stubOrMockResult = __stubFunction(a1, a2)
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
+                        value = __stubs_globalAa.__globalStubs.sayhello
+                        return value
+                    end if
+                    print "hello"
+                end function
+
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
+
         });
 
-        describe('basic brs tests', () => {
+        it('weird raletracker task issue I saw', async () => {
+            program.setFile('source/code.bs', `
+                Sub RedLines_SetRulerLines(rulerLines)
+                    For Each line In rulerLines.Items()
+                        RedLines_AddLine(line.key, line.value.position, line.value.coords, m.node, m.childMap)
+                    End For
+                end Sub
+                Sub RedLines_AddLine(id, position, coords, node, childMap) as Object
+                    line = CreateObject("roSGNode", "Rectangle")
+                    line.setField("id", id)
+                end sub
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                Sub RedLines_SetRulerLines(rulerLines)
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["redlines_setrulerlines"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["redlines_setrulerlines"].callback(rulerLines)
+                        return
+                    else if type(__stubs_globalAa?.__globalStubs?.redlines_setrulerlines).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.redlines_setrulerlines
+                        __stubOrMockResult = __stubFunction(rulerLines)
+                        return
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("redlines_setrulerlines")
+                        value = __stubs_globalAa.__globalStubs.redlines_setrulerlines
+                        return
+                    end if
+                    For Each line In rulerLines.Items()
+                        RedLines_AddLine(line.key, line.value.position, line.value.coords, m.node, m.childMap)
+                    End For
+                end Sub
 
-            // This test fails unless `allowBrighterScriptInBrightScript` is set to true when setting up the program
-            // in `beforeEach`. This is because the compiler normally skips processing .brs files and copies them as-is.
-            it('adds util code to a brs file', async () => {
-                program.setFile('source/code.brs', `
-                    function sayHello(a1, a2)
-                        print "hello"
-                    end function
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    function sayHello(a1, a2)
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback(a1, a2)
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.sayhello
-                            __stubOrMockResult = __stubFunction(a1, a2)
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
-                            value = __stubs_globalAa.__globalStubs.sayhello
-                            return value
-                        end if
-                        print "hello"
-                    end function
+                Sub RedLines_AddLine(id, position, coords, node, childMap) as Object
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["redlines_addline"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["redlines_addline"].callback(id, position, coords, node, childMap)
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.redlines_addline).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.redlines_addline
+                        __stubOrMockResult = __stubFunction(id, position, coords, node, childMap)
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("redlines_addline")
+                        value = __stubs_globalAa.__globalStubs.redlines_addline
+                        return value
+                    end if
+                    line = CreateObject("roSGNode", "Rectangle")
+                    line.setField("id", id)
+                end sub
 
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
 
-            });
         });
-        describe('basic bs tests', () => {
 
-            it('enables mocking on global functions', async () => {
-                program.setFile('source/code.bs', `
+        it('enables mocking on global sub', async () => {
+            program.setFile('source/code.bs', `
+                sub sayHello(a1, a2)
+                    print "hello"
+                end sub
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                sub sayHello(a1, a2)
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback(a1, a2)
+                        return
+                    else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.sayhello
+                        __stubOrMockResult = __stubFunction(a1, a2)
+                        return
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
+                        value = __stubs_globalAa.__globalStubs.sayhello
+                        return
+                    end if
+                    print "hello"
+                end sub
+
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
+        });
+
+        it('enables mocking on namespaced function', async () => {
+            program.setFile('source/code.bs', `
+                namespace person.utils
                     function sayHello(a1, a2)
                         print "hello"
                     end function
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    function sayHello(a1, a2)
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback(a1, a2)
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.sayhello
-                            __stubOrMockResult = __stubFunction(a1, a2)
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
-                            value = __stubs_globalAa.__globalStubs.sayhello
-                            return value
-                        end if
-                        print "hello"
-                    end function
+                end namespace
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                function person_utils_sayHello(a1, a2)
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"].callback(a1, a2)
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.person_utils_sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.person_utils_sayhello
+                        __stubOrMockResult = __stubFunction(a1, a2)
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("person_utils_sayhello")
+                        value = __stubs_globalAa.__globalStubs.person_utils_sayhello
+                        return value
+                    end if
+                    print "hello"
+                end function
 
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
 
-            });
-            it('weird raletracker task issue I saw', async () => {
-                program.setFile('source/code.bs', `
-                    Sub RedLines_SetRulerLines(rulerLines)
-                        For Each line In rulerLines.Items()
-                            RedLines_AddLine(line.key, line.value.position, line.value.coords, m.node, m.childMap)
-                        End For
-                    end Sub
-                    Sub RedLines_AddLine(id, position, coords, node, childMap) as Object
-                        line = CreateObject("roSGNode", "Rectangle")
-                        line.setField("id", id)
-                    end sub
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    Sub RedLines_SetRulerLines(rulerLines)
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["redlines_setrulerlines"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["redlines_setrulerlines"].callback(rulerLines)
-                            return
-                        else if type(__stubs_globalAa?.__globalStubs?.redlines_setrulerlines).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.redlines_setrulerlines
-                            __stubOrMockResult = __stubFunction(rulerLines)
-                            return
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("redlines_setrulerlines")
-                            value = __stubs_globalAa.__globalStubs.redlines_setrulerlines
-                            return
-                        end if
-                        For Each line In rulerLines.Items()
-                            RedLines_AddLine(line.key, line.value.position, line.value.coords, m.node, m.childMap)
-                        End For
-                    end Sub
+        });
 
-                    Sub RedLines_AddLine(id, position, coords, node, childMap) as Object
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["redlines_addline"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["redlines_addline"].callback(id, position, coords, node, childMap)
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.redlines_addline).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.redlines_addline
-                            __stubOrMockResult = __stubFunction(id, position, coords, node, childMap)
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("redlines_addline")
-                            value = __stubs_globalAa.__globalStubs.redlines_addline
-                            return value
-                        end if
-                        line = CreateObject("roSGNode", "Rectangle")
-                        line.setField("id", id)
-                    end sub
-
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
-
-            });
-
-            it('enables mocking on global sub', async () => {
-                program.setFile('source/code.bs', `
+        it('enables mocking on namespaced sub', async () => {
+            program.setFile('source/code.bs', `
+                namespace person.utils
                     sub sayHello(a1, a2)
                         print "hello"
                     end sub
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    sub sayHello(a1, a2)
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback(a1, a2)
-                            return
-                        else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.sayhello
-                            __stubOrMockResult = __stubFunction(a1, a2)
-                            return
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
-                            value = __stubs_globalAa.__globalStubs.sayhello
-                            return
-                        end if
-                        print "hello"
-                    end sub
+                end namespace
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                sub person_utils_sayHello(a1, a2)
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"].callback(a1, a2)
+                        return
+                    else if type(__stubs_globalAa?.__globalStubs?.person_utils_sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.person_utils_sayhello
+                        __stubOrMockResult = __stubFunction(a1, a2)
+                        return
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("person_utils_sayhello")
+                        value = __stubs_globalAa.__globalStubs.person_utils_sayhello
+                        return
+                    end if
+                    print "hello"
+                end sub
 
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
 
-            });
+        });
 
-            it('enables mocking on namespaced function', async () => {
-                program.setFile('source/code.bs', `
-                    namespace person.utils
-                        function sayHello(a1, a2)
-                            print "hello"
-                        end function
-                    end namespace
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    function person_utils_sayHello(a1, a2)
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"].callback(a1, a2)
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.person_utils_sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.person_utils_sayhello
-                            __stubOrMockResult = __stubFunction(a1, a2)
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("person_utils_sayhello")
-                            value = __stubs_globalAa.__globalStubs.person_utils_sayhello
-                            return value
-                        end if
-                        print "hello"
-                    end function
-
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
-
-            });
-
-            it('enables mocking on namespaced sub', async () => {
-                program.setFile('source/code.bs', `
-                    namespace person.utils
-                        sub sayHello(a1, a2)
-                            print "hello"
-                        end sub
-                    end namespace
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    sub person_utils_sayHello(a1, a2)
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["person_utils_sayhello"].callback(a1, a2)
-                            return
-                        else if type(__stubs_globalAa?.__globalStubs?.person_utils_sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.person_utils_sayhello
-                            __stubOrMockResult = __stubFunction(a1, a2)
-                            return
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("person_utils_sayhello")
-                            value = __stubs_globalAa.__globalStubs.person_utils_sayhello
-                            return
-                        end if
-                        print "hello"
-                    end sub
-
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
-
-            });
-
-            it('does not affect class methods', async () => {
-                program.setFile('source/code.bs', `
+        it('does not affect class methods', async () => {
+            program.setFile('source/code.bs', `
                 class Person
                     sub sayHello(a1, a2)
                         print "hello"
                     end sub
                 end class
             `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    sub __Person_method_new()
-                    end sub
-                    sub __Person_method_sayHello(a1, a2)
-                        print "hello"
-                    end sub
-                    function __Person_builder()
-                        instance = {}
-                        instance.new = __Person_method_new
-                        instance.sayHello = __Person_method_sayHello
-                        return instance
-                    end function
-                    function Person()
-                        instance = __Person_builder()
-                        instance.new()
-                        return instance
-                    end function
-                `);
-                expect(a).to.equal(b);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                sub __Person_method_new()
+                end sub
+                sub __Person_method_sayHello(a1, a2)
+                    print "hello"
+                end sub
+                function __Person_builder()
+                    instance = {}
+                    instance.new = __Person_method_new
+                    instance.sayHello = __Person_method_sayHello
+                    return instance
+                end function
+                function Person()
+                    instance = __Person_builder()
+                    instance.new()
+                    return instance
+                end function
+            `);
+            expect(a).to.equal(b);
 
-            });
-            it('will add stub code to namespace and global methods in a file with a class', async () => {
-                program.setFile('source/code.bs', `
+        });
+        it('will add stub code to namespace and global methods in a file with a class', async () => {
+            program.setFile('source/code.bs', `
                 namespace beings
                 class Person
                     sub sayHello(a1, a2)
@@ -367,142 +362,139 @@ describe('MockUtil', () => {
                     print "hello3"
                 end function
             `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    sub __beings_Person_method_new()
-                    end sub
-                    sub __beings_Person_method_sayHello(a1, a2)
-                        print "hello"
-                    end sub
-                    function __beings_Person_builder()
-                        instance = {}
-                        instance.new = __beings_Person_method_new
-                        instance.sayHello = __beings_Person_method_sayHello
-                        return instance
-                    end function
-                    function beings_Person()
-                        instance = __beings_Person_builder()
-                        instance.new()
-                        return instance
-                    end function
-
-                    function beings_sayHello()
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["beings_sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["beings_sayhello"].callback()
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.beings_sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.beings_sayhello
-                            __stubOrMockResult = __stubFunction()
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("beings_sayhello")
-                            value = __stubs_globalAa.__globalStubs.beings_sayhello
-                            return value
-                        end if
-                        print "hello2"
-                    end function
-
-                    function sayHello()
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback()
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.sayhello
-                            __stubOrMockResult = __stubFunction()
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
-                            value = __stubs_globalAa.__globalStubs.sayhello
-                            return value
-                        end if
-                        print "hello3"
-                    end function
-
-                    function RBS_SM_1_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `);
-                expect(a).to.equal(b);
-
-            });
-
-            it('will skip functions with the disableMocking annotation', async () => {
-                program.setFile('source/code.bs', `
-                    @disableMocking
-                    namespace beings
-                    function sayHello()
-                        print "hello2"
-                    end function
-                    end namespace
-                    namespace aliens
-                    @disableMocking
-                    function sayHello()
-                        print "hello3"
-                    end function
-                    end namespace
-                    @disableMocking
-                    function sayHello()
-                        print "hello4"
-                    end function
-                `);
-                program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                await builder.transpile();
-                let a = getContents('source/code.brs');
-                let b = undent(`
-                    function beings_sayHello()
-                        print "hello2"
-                    end function
-                    function aliens_sayHello()
-                        print "hello3"
-                    end function
-
-                    function sayHello()
-                        print "hello4"
-                    end function
-                `);
-                expect(a).to.equal(b);
-
-            });
-
-        });
-
-        it('excludes files from coverage', async () => {
-            const source = `
-                sub foo()
-                    x = function(y)
-                        if (true) then
-                            return 1
-                        end if
-                        return 0
-                    end function
-                end sub
-            `;
-
-            program.setFile('source/code.coverageExcluded.bs', source);
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             await builder.transpile();
-
-            let a = getContents('source/code.coverageExcluded.brs');
+            let a = getContents('source/code.brs');
             let b = undent(`
-                sub foo()
-                    x = function(y)
-                        if (true) then
-                            return 1
-                        end if
-                        return 0
-                    end function
+                sub __beings_Person_method_new()
                 end sub
-            `);
+                sub __beings_Person_method_sayHello(a1, a2)
+                    print "hello"
+                end sub
+                function __beings_Person_builder()
+                    instance = {}
+                    instance.new = __beings_Person_method_new
+                    instance.sayHello = __beings_Person_method_sayHello
+                    return instance
+                end function
+                function beings_Person()
+                    instance = __beings_Person_builder()
+                    instance.new()
+                    return instance
+                end function
 
+                function beings_sayHello()
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["beings_sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["beings_sayhello"].callback()
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.beings_sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.beings_sayhello
+                        __stubOrMockResult = __stubFunction()
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("beings_sayhello")
+                        value = __stubs_globalAa.__globalStubs.beings_sayhello
+                        return value
+                    end if
+                    print "hello2"
+                end function
+
+                function sayHello()
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_1_getMocksByFunctionName()["sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_1_getMocksByFunctionName()["sayhello"].callback()
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.sayhello
+                        __stubOrMockResult = __stubFunction()
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("sayhello")
+                        value = __stubs_globalAa.__globalStubs.sayhello
+                        return value
+                    end if
+                    print "hello3"
+                end function
+
+                function RBS_SM_1_getMocksByFunctionName()
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                end function
+            `);
+            expect(a).to.equal(b);
+
+        });
+
+        it('will skip functions with the disableMocking annotation', async () => {
+            program.setFile('source/code.bs', `
+                @disableMocking
+                namespace beings
+                function sayHello()
+                    print "hello2"
+                end function
+                end namespace
+                namespace aliens
+                @disableMocking
+                function sayHello()
+                    print "hello3"
+                end function
+                end namespace
+                @disableMocking
+                function sayHello()
+                    print "hello4"
+                end function
+            `);
+            program.validate();
+            expect(program.getDiagnostics()).to.be.empty;
+            await builder.transpile();
+            let a = getContents('source/code.brs');
+            let b = undent(`
+                function beings_sayHello()
+                    print "hello2"
+                end function
+                function aliens_sayHello()
+                    print "hello3"
+                end function
+
+                function sayHello()
+                    print "hello4"
+                end function
+            `);
             expect(a).to.equal(b);
         });
+    });
+
+    it('excludes files from coverage', async () => {
+        const source = `
+            sub foo()
+                x = function(y)
+                    if (true) then
+                        return 1
+                    end if
+                    return 0
+                end function
+            end sub
+        `;
+
+        program.setFile('source/code.coverageExcluded.bs', source);
+        program.validate();
+        expect(program.getDiagnostics()).to.be.empty;
+        await builder.transpile();
+
+        let a = getContents('source/code.coverageExcluded.brs');
+        let b = undent(`
+            sub foo()
+                x = function(y)
+                    if (true) then
+                        return 1
+                    end if
+                    return 0
+                end function
+            end sub
+        `);
+
+        expect(a).to.equal(b);
     });
 });

--- a/src/lib/rooibos/TestSuiteBuilder.ts
+++ b/src/lib/rooibos/TestSuiteBuilder.ts
@@ -60,7 +60,7 @@ export class TestSuiteBuilder {
             }
         } catch (e) {
             // console.log(e);
-            diagnosticErrorProcessingFile(file, e.message);
+            diagnosticErrorProcessingFile(file, (e as Error).message);
         }
         this.session.sessionInfo.updateTestSuites(suites);
         return suites;

--- a/src/lib/utils/Diagnostics.ts
+++ b/src/lib/utils/Diagnostics.ts
@@ -39,7 +39,7 @@ function addDiagnosticForAnnotation(
 ) {
     let line = annotation.range.start.line;
     let col = annotation.range.start.character;
-
+    // TODO: Fix the end character to be the end of the annotation, not the start + 9999
     file.addDiagnostics([createDiagnostic(file, code, message, line, col, annotation.range.end.line, annotation.range.end.character + 9999, severity)]);
 }
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -2561,7 +2561,7 @@ describe('RooibosPlugin', () => {
                 end if
             `);
 
-            const runtimeConfigContents = getContents('rooibos/RuntimeConfig.brs');
+            const runtimeConfigContents = getContents('source/rooibos/RuntimeConfig.brs');
 
             const runtimeConfigAst = getAstFromFileContents(runtimeConfigContents);
 
@@ -2571,11 +2571,11 @@ describe('RooibosPlugin', () => {
             expect(commentedImports[0].text).to.include('pkg:/source/rooibos/ConsoleTestReporter.bs');
             expect(commentedImports[0].text).to.include('pkg:/source/rooibos/MochaTestReporter.bs');
 
-            expectFunctionContents(getContents('rooibos/RuntimeConfig.brs'), '__rooibos_RuntimeConfig_method_getVersionText', `
+            expectFunctionContents(runtimeConfigContents, '__rooibos_RuntimeConfig_method_getVersionText', `
                 return "${version}"
             `);
 
-            expectFunctionContents(getContents('rooibos/RuntimeConfig.brs'), '__rooibos_RuntimeConfig_method_getRuntimeConfig', `
+            expectFunctionContents(runtimeConfigContents, '__rooibos_RuntimeConfig_method_getRuntimeConfig', `
                 return {
                     "reporters": [
                         rooibos_ConsoleTestReporter
@@ -2596,7 +2596,7 @@ describe('RooibosPlugin', () => {
                 }
             `);
 
-            expectFunctionContents(getContents('rooibos/RuntimeConfig.brs'), '__rooibos_RuntimeConfig_method_getTestSuiteClassMap', `
+            expectFunctionContents(runtimeConfigContents, '__rooibos_RuntimeConfig_method_getTestSuiteClassMap', `
                 return {
                     "ATest1": ATest1
                     "ATest2": ATest2
@@ -2656,7 +2656,7 @@ describe('RooibosPlugin', () => {
                 `;
 
                 const runtimeConfigContents = getFunctionContents(
-                    getContents('rooibos/RuntimeConfig.brs'),
+                    getContents('source/rooibos/RuntimeConfig.brs'),
                     /^__rooibos_RuntimeConfig_method_getRuntimeConfig$/
                 );
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1,10 +1,12 @@
 import type { BrsFile, CallExpression, ClassMethodStatement, ClassStatement, ExpressionStatement } from 'brighterscript';
-import { CallfuncExpression, DiagnosticSeverity, DottedGetExpression, FunctionStatement, Parser, Position, Program, ProgramBuilder, util, standardizePath as s, PrintStatement } from 'brighterscript';
+import { CallfuncExpression, DiagnosticSeverity, DottedGetExpression, FunctionStatement, Parser, Position, Program, ProgramBuilder, util, standardizePath as s, PrintStatement, isMethodStatement } from 'brighterscript';
 import { expect } from 'chai';
 import { RooibosPlugin } from './plugin';
 import * as fsExtra from 'fs-extra';
 import undent from 'undent';
 import { SourceMapConsumer } from 'source-map';
+import type { TestCase } from './lib/rooibos/TestCase';
+import { expectTestCaseFunctionName, TestCaseMD5Sum } from './testHelpers.spec';
 let tmpPath = s`${process.cwd()}/.tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
 let _stagingFolderPath = s`${tmpPath}/staging`;
@@ -389,9 +391,14 @@ describe('RooibosPlugin', () => {
             expect(plugin.session.sessionInfo.testSuitesToRun.length).to.be.equal(1);
             expect(plugin.session.sessionInfo.groupsCount).to.equal(1);
             expect(plugin.session.sessionInfo.testsCount).to.equal(1);
-            expect([...plugin.session.sessionInfo.testSuites.entries()][0][1].isIgnored).to.equal(true);
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].isIgnored).to.equal(true);
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].testCases[0].isIgnored).to.equal(true);
+            const testSuite = plugin.session.sessionInfo.testSuites.get('ATest');
+            expect(testSuite.isIgnored).to.equal(true);
+            for (let groupa of testSuite.testGroups.values()) {
+                expect(groupa.isIgnored).to.equal(true);
+                for (let test of groupa.testCases) {
+                    expect(test.isIgnored).to.equal(true);
+                }
+            }
         });
 
         it('ignores a group', () => {
@@ -412,9 +419,9 @@ describe('RooibosPlugin', () => {
             expect(plugin.session.sessionInfo.testSuitesToRun.length).to.be.equal(1);
             expect(plugin.session.sessionInfo.groupsCount).to.equal(1);
             expect(plugin.session.sessionInfo.testsCount).to.equal(1);
-            expect([...plugin.session.sessionInfo.testSuites.entries()][0][1].isIgnored).to.equal(false);
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].isIgnored).to.equal(true);
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].testCases[0].isIgnored).to.equal(true);
+            const testSuite = plugin.session.sessionInfo.testSuites.get('ATest');
+            const testGroup = testSuite.testGroups.get('groupA');
+            expect(testGroup.isIgnored).to.equal(true);
         });
 
         it('ignores a test', () => {
@@ -436,9 +443,10 @@ describe('RooibosPlugin', () => {
             expect(plugin.session.sessionInfo.testSuitesToRun.length).to.be.equal(1);
             expect(plugin.session.sessionInfo.groupsCount).to.equal(1);
             expect(plugin.session.sessionInfo.testsCount).to.equal(1);
-            expect([...plugin.session.sessionInfo.testSuites.entries()][0][1].isIgnored).to.equal(false);
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].isIgnored).to.equal(false);
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].testCases[0].isIgnored).to.equal(true);
+            const testSuite = plugin.session.sessionInfo.testSuites.get('ATest');
+            const testGroup = testSuite.testGroups.get('groupA');
+            expect(testGroup.testCases[0].name).to.equal('is test1');
+            expect(testGroup.testCases[0].isIgnored).to.equal(true);
         });
 
         it('multiple groups', () => {
@@ -495,12 +503,23 @@ describe('RooibosPlugin', () => {
             program.validate();
 
             expect(program.getDiagnostics()).to.be.empty;
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].testCases[0].funcName).to.equal('rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0');
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][0][1].testCases[0].name).to.equal('is test1');
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][1][1].testCases[0].funcName).to.equal('rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_1');
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][1][1].testCases[0].name).to.equal('is test1');
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][1][1].testCases[1].funcName).to.equal('rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_2');
-            expect([...[...plugin.session.sessionInfo.testSuites.entries()][0][1].testGroups.entries()][1][1].testCases[1].name).to.equal('is test1');
+            const testSuite = plugin.session.sessionInfo.testSuites.get('ATest');
+
+
+            const allTestCases: TestCase[] = [].concat(...testSuite.getTestGroups().map(group => group.testCases));
+
+            expect(allTestCases).to.be.length(3);
+
+            // each has different function name
+            expectTestCaseFunctionName(allTestCases[0], 0);
+            expectTestCaseFunctionName(allTestCases[1], 1);
+            expectTestCaseFunctionName(allTestCases[2], 2);
+
+            // all have same test name
+            for (let testCase of allTestCases) {
+                expect(testCase.name).to.equal('is test1');
+            }
+
             expect(plugin.session.sessionInfo.testSuitesToRun).to.be.length(1);
         });
 
@@ -638,7 +657,7 @@ describe('RooibosPlugin', () => {
             `, `
                 sub __ATest_method_new()
                 end sub
-                function __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0()
+                function __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0()
                     number = 123
                     m.assertEqual("123", ("alpha-" + bslib_toString(number) + "-beta"))
                     m.assertEqual(123, 123)
@@ -646,7 +665,7 @@ describe('RooibosPlugin', () => {
                 function __ATest_builder()
                     instance = {}
                     instance.new = __ATest_method_new
-                    instance.rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0 = __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0
+                    instance.rooiboos_test_case_${TestCaseMD5Sum}_0 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0
                     return instance
                 end function
                 function ATest()
@@ -717,7 +736,7 @@ describe('RooibosPlugin', () => {
                 sub __ATest_method_new()
                     m.super0_new()
                 end sub
-                function __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0()
+                function __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0()
                     m.currentAssertLineNumber = 8
                     m.assertEqual(1, 1)
                     if m.currentResult?.isFail = true then
@@ -741,7 +760,7 @@ describe('RooibosPlugin', () => {
                         end if
                     end if
                 end function
-                sub __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_1()
+                sub __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_1()
                     m.currentAssertLineNumber = 18
                     m.assertEqual(1, 1)
                     if m.currentResult?.isFail = true then
@@ -805,7 +824,7 @@ describe('RooibosPlugin', () => {
                                     {
                                         isSolo: false
                                         noCatch: false
-                                        funcName: "rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0"
+                                        funcName: "rooiboos_test_case_${TestCaseMD5Sum}_0"
                                         isIgnored: false
                                         isAsync: false
                                         asyncTimeout: 2000
@@ -823,7 +842,7 @@ describe('RooibosPlugin', () => {
                                     {
                                         isSolo: false
                                         noCatch: false
-                                        funcName: "rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_1"
+                                        funcName: "rooiboos_test_case_${TestCaseMD5Sum}_1"
                                         isIgnored: false
                                         isAsync: false
                                         asyncTimeout: 2000
@@ -847,8 +866,8 @@ describe('RooibosPlugin', () => {
                     instance = __rooibos_BaseTestSuite_builder()
                     instance.super0_new = instance.new
                     instance.new = __ATest_method_new
-                    instance.rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0 = __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0
-                    instance.rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_1 = __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_1
+                    instance.rooiboos_test_case_${TestCaseMD5Sum}_0 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0
+                    instance.rooiboos_test_case_${TestCaseMD5Sum}_1 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_1
                     instance.super0_getTestSuiteData = instance.getTestSuiteData
                     instance.getTestSuiteData = __ATest_method_getTestSuiteData
                     return instance
@@ -862,8 +881,8 @@ describe('RooibosPlugin', () => {
 
             //verify the AST was restored after transpile
             const cls = file.ast.statements[0] as ClassStatement;
-            expect(cls.body.find((x: ClassMethodStatement) => {
-                return x.name?.text.toLowerCase() === 'getTestSuiteData'.toLowerCase();
+            expect(cls.body.find((x) => {
+                return isMethodStatement(x) && x.name?.text.toLowerCase() === 'getTestSuiteData'.toLowerCase();
             })).not.to.exist;
         });
 
@@ -903,7 +922,7 @@ describe('RooibosPlugin', () => {
                 sub __ATest_method_new()
                     m.super0_new()
                 end sub
-                function __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0()
+                function __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0()
                 end function
                 function __ATest_method_getTestSuiteData()
                     return {
@@ -945,7 +964,7 @@ describe('RooibosPlugin', () => {
                                     {
                                         isSolo: false
                                         noCatch: false
-                                        funcName: "rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0"
+                                        funcName: "rooiboos_test_case_${TestCaseMD5Sum}_0"
                                         isIgnored: false
                                         isAsync: false
                                         asyncTimeout: 2000
@@ -969,7 +988,7 @@ describe('RooibosPlugin', () => {
                     instance = __rooibos_BaseTestSuite_builder()
                     instance.super0_new = instance.new
                     instance.new = __ATest_method_new
-                    instance.rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0 = __ATest_method_rooiboos_test_case_0d635a9477c4624180ef87bef352afd3_0
+                    instance.rooiboos_test_case_${TestCaseMD5Sum}_0 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0
                     instance.super0_getTestSuiteData = instance.getTestSuiteData
                     instance.getTestSuiteData = __ATest_method_getTestSuiteData
                     return instance
@@ -983,8 +1002,8 @@ describe('RooibosPlugin', () => {
 
             //verify the AST was restored after transpile
             const cls = file.ast.statements[0] as ClassStatement;
-            expect(cls.body.find((x: ClassMethodStatement) => {
-                return x.name?.text.toLowerCase() === 'getTestSuiteData'.toLowerCase();
+            expect(cls.body.find((x) => {
+                return isMethodStatement(x) && x.name?.text.toLowerCase() === 'getTestSuiteData'.toLowerCase();
             })).not.to.exist;
         });
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1,5 +1,5 @@
-import type { BrsFile, CallExpression, ClassMethodStatement, ClassStatement, CommentStatement, ExpressionStatement, FunctionStatement, ImportStatement } from 'brighterscript';
-import { CallfuncExpression, DiagnosticSeverity, DottedGetExpression, Parser, Position, Program, ProgramBuilder, util, standardizePath as s, PrintStatement, isMethodStatement, isFunctionStatement, isReturnStatement, isAALiteralExpression, isImportStatement, isCommentStatement } from 'brighterscript';
+import type { BrsFile, CallExpression, ClassStatement, CommentStatement, ExpressionStatement, FunctionStatement, MethodStatement } from 'brighterscript';
+import { CallfuncExpression, DiagnosticSeverity, DottedGetExpression, Position, Program, ProgramBuilder, util, standardizePath as s, PrintStatement, isMethodStatement, isFunctionStatement, isReturnStatement, isAALiteralExpression, isCommentStatement } from 'brighterscript';
 import { expect } from 'chai';
 import { RooibosPlugin } from './plugin';
 import * as fsExtra from 'fs-extra';
@@ -393,9 +393,9 @@ describe('RooibosPlugin', () => {
             expect(plugin.session.sessionInfo.testsCount).to.equal(1);
             const testSuite = plugin.session.sessionInfo.testSuites.get('ATest');
             expect(testSuite.isIgnored).to.equal(true);
-            for (let groupa of testSuite.testGroups.values()) {
-                expect(groupa.isIgnored).to.equal(true);
-                for (let test of groupa.testCases) {
+            for (let group of testSuite.testGroups.values()) {
+                expect(group.isIgnored).to.equal(true);
+                for (let test of group.testCases) {
                     expect(test.isIgnored).to.equal(true);
                 }
             }
@@ -2230,7 +2230,7 @@ describe('RooibosPlugin', () => {
                     end if
                 `);
                 //verify original code does not remain modified after the transpile cycle
-                const testMethod = ((file.ast.statements[0] as ClassStatement).memberMap['_'] as ClassMethodStatement);
+                const testMethod = ((file.ast.statements[0] as ClassStatement).memberMap['_'] as MethodStatement);
 
                 const call1 = (testMethod.func.body.statements[1] as ExpressionStatement).expression as CallExpression;
                 expect(call1.args).to.be.lengthOf(1);
@@ -2270,7 +2270,7 @@ describe('RooibosPlugin', () => {
                     end if
                 `);
                 //verify original code does not remain modified after the transpile cycle
-                const testMethod = ((file.ast.statements[0] as ClassStatement).memberMap['_'] as ClassMethodStatement);
+                const testMethod = ((file.ast.statements[0] as ClassStatement).memberMap['_'] as MethodStatement);
                 const call = (testMethod.func.body.statements[0] as ExpressionStatement).expression as CallExpression;
                 const arg0 = call.args[0] as DottedGetExpression;
                 expect(call.args).to.be.lengthOf(1);

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -727,9 +727,9 @@ describe('RooibosPlugin', () => {
             `);
             program.validate();
             await builder.transpile();
-            console.log(builder.getDiagnostics());
-            expect(builder.getDiagnostics()).to.have.length(1);
-            expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+            expectDiagnostics(program, [
+                { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+            ]);
             expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
             expect(plugin.session.sessionInfo.suitesCount).to.equal(1);
             expect(plugin.session.sessionInfo.groupsCount).to.equal(1);
@@ -2397,9 +2397,9 @@ describe('RooibosPlugin', () => {
                 program.setFile('source/test.spec.bs', testSource);
                 program.validate();
                 await builder.transpile();
-                console.log(builder.getDiagnostics());
-                expect(builder.getDiagnostics()).to.have.length(1);
-                expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+                expectDiagnostics(program, [
+                    { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+                ]);
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun[0].name).to.equal('a');
                 expect(plugin.session.sessionInfo.testSuitesToRun[1].name).to.equal('b');
@@ -2410,9 +2410,9 @@ describe('RooibosPlugin', () => {
                 program.setFile('source/test.spec.bs', testSource);
                 program.validate();
                 await builder.transpile();
-                console.log(builder.getDiagnostics());
-                expect(builder.getDiagnostics()).to.have.length(1);
-                expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+                expectDiagnostics(program, [
+                    { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+                ]);
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun[0].name).to.equal('a');
             });
@@ -2422,9 +2422,9 @@ describe('RooibosPlugin', () => {
                 program.setFile('source/test.spec.bs', testSource);
                 program.validate();
                 await builder.transpile();
-                console.log(builder.getDiagnostics());
-                expect(builder.getDiagnostics()).to.have.length(1);
-                expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+                expectDiagnostics(program, [
+                    { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+                ]);
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun[0].name).to.equal('b');
             });
@@ -2434,9 +2434,9 @@ describe('RooibosPlugin', () => {
                 program.setFile('source/test.spec.bs', testSource);
                 program.validate();
                 await builder.transpile();
-                console.log(builder.getDiagnostics());
-                expect(builder.getDiagnostics()).to.have.length(1);
-                expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+                expectDiagnostics(program, [
+                    { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+                ]);
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun[0].name).to.equal('b');
             });
@@ -2447,9 +2447,9 @@ describe('RooibosPlugin', () => {
                 program.setFile('source/test.spec.bs', testSource);
                 program.validate();
                 await builder.transpile();
-                console.log(builder.getDiagnostics());
-                expect(builder.getDiagnostics()).to.have.length(1);
-                expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+                expectDiagnostics(program, [
+                    { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+                ]);
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.be.empty;
             });
 
@@ -2458,9 +2458,9 @@ describe('RooibosPlugin', () => {
                 program.setFile('source/test.spec.bs', testSource);
                 program.validate();
                 await builder.transpile();
-                console.log(builder.getDiagnostics());
-                expect(builder.getDiagnostics()).to.have.length(1);
-                expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+                expectDiagnostics(program, [
+                    { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+                ]);
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun[0].name).to.equal('a');
             });
@@ -2723,7 +2723,6 @@ describe('RooibosPlugin', () => {
             ).catch(e => {
                 console.error(e, !swv);
             });
-            console.log('done');
         });
     });
 

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -1,12 +1,12 @@
-import type { BrsFile, CallExpression, ClassMethodStatement, ClassStatement, ExpressionStatement } from 'brighterscript';
-import { CallfuncExpression, DiagnosticSeverity, DottedGetExpression, FunctionStatement, Parser, Position, Program, ProgramBuilder, util, standardizePath as s, PrintStatement, isMethodStatement } from 'brighterscript';
+import type { BrsFile, CallExpression, ClassMethodStatement, ClassStatement, CommentStatement, ExpressionStatement, FunctionStatement, ImportStatement } from 'brighterscript';
+import { CallfuncExpression, DiagnosticSeverity, DottedGetExpression, Parser, Position, Program, ProgramBuilder, util, standardizePath as s, PrintStatement, isMethodStatement, isFunctionStatement, isReturnStatement, isAALiteralExpression, isImportStatement, isCommentStatement } from 'brighterscript';
 import { expect } from 'chai';
 import { RooibosPlugin } from './plugin';
 import * as fsExtra from 'fs-extra';
 import undent from 'undent';
 import { SourceMapConsumer } from 'source-map';
 import type { TestCase } from './lib/rooibos/TestCase';
-import { expectTestCaseFunctionName, TestCaseMD5Sum } from './testHelpers.spec';
+import { expectFunctionContents, expectDiagnostics, expectZeroDiagnostics, expectTestCaseFunctionName, getTestFunctionContents, TestCaseMD5Sum, getAstFromFileContents, expectFunctionContentsContains, expectTestFunctionContents, getContents, normalizeGeneratedMockFunctionNames, getFunctionContents } from './testHelpers.spec';
 let tmpPath = s`${process.cwd()}/.tmp`;
 let _rootDir = s`${tmpPath}/rootDir`;
 let _stagingFolderPath = s`${tmpPath}/staging`;
@@ -568,6 +568,8 @@ describe('RooibosPlugin', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
+            const testGroup = plugin.session.sessionInfo.testSuites.get('ATest').testGroups.get('groupA');
+            expect(testGroup.testCases).to.be.length(4);
         });
 
         it('updates test name to match name of annotation', () => {
@@ -586,6 +588,9 @@ describe('RooibosPlugin', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
+            const testGroup = plugin.session.sessionInfo.testSuites.get('ATest').testGroups.get('groupA');
+            expect(testGroup.testCases[0].name).to.equal('is test1');
+            expect(testGroup.testCases[1].name).to.equal('is test2');
         });
 
         it('updates test name to match name of annotation - with params', () => {
@@ -606,6 +611,9 @@ describe('RooibosPlugin', () => {
             program.validate();
             expect(program.getDiagnostics()).to.be.empty;
             expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
+            const testGroup = plugin.session.sessionInfo.testSuites.get('ATest').testGroups.get('groupA');
+            expect(testGroup.testCases[0].name).to.equal('is test1');
+            expect(testGroup.testCases[1].name).to.equal('is test2');
         });
 
         it('multiple test group annotations - different name', () => {
@@ -621,6 +629,10 @@ describe('RooibosPlugin', () => {
             `);
             program.validate();
             expect(program.getDiagnostics()).to.not.be.empty;
+            expectDiagnostics(program, [
+                { code: 'RBS2218' },
+                { code: 'RBS2218' }
+            ]);
             expect(plugin.session.sessionInfo.testSuitesToRun).to.be.empty;
         });
 
@@ -730,155 +742,98 @@ describe('RooibosPlugin', () => {
                     Rooibos_init("RooibosScene")
                 end function
             `);
-            expect(
-                getContents('test.spec.brs')
-            ).to.eql(undent`
-                sub __ATest_method_new()
-                    m.super0_new()
-                end sub
-                function __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0()
-                    m.currentAssertLineNumber = 8
-                    m.assertEqual(1, 1)
-                    if m.currentResult?.isFail = true then
-                        m.done()
-                        return invalid
-                    end if
-                    if 1 = 1
-                        m.currentAssertLineNumber = 10
-                        m.assertEqual(2, 2)
-                        if m.currentResult?.isFail = true then
-                            m.done()
-                            return invalid
-                        end if
-                        if 2 = 2
-                            m.currentAssertLineNumber = 12
-                            m.assertTrue(false)
-                            if m.currentResult?.isFail = true then
-                                m.done()
-                                return invalid
-                            end if
-                        end if
-                    end if
-                end function
-                sub __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_1()
-                    m.currentAssertLineNumber = 18
-                    m.assertEqual(1, 1)
-                    if m.currentResult?.isFail = true then
-                        m.done()
-                        return
-                    end if
-                    if 1 = 1
-                        m.currentAssertLineNumber = 20
-                        m.assertEqual(2, 2)
-                        if m.currentResult?.isFail = true then
-                            m.done()
-                            return
-                        end if
-                        if 2 = 2
-                            m.currentAssertLineNumber = 22
-                            m.assertTrue(false)
-                            if m.currentResult?.isFail = true then
-                                m.done()
-                                return
-                            end if
-                        end if
-                    end if
-                end sub
-                function __ATest_method_getTestSuiteData()
-                    return {
-                        name: "ATest"
-                        isSolo: false
-                        noCatch: false
-                        isIgnored: false
-                        isAsync: false
-                        pkgPath: "${s`source/test.spec.bs`}"
-                        filePath: "${s`${tmpPath}/rootDir/source/test.spec.bs`}"
-                        lineNumber: 3
-                        valid: true
-                        hasFailures: false
-                        hasSoloTests: false
-                        hasIgnoredTests: false
-                        hasSoloGroups: false
-                        setupFunctionName: ""
-                        tearDownFunctionName: ""
-                        beforeEachFunctionName: ""
-                        afterEachFunctionName: ""
-                        isNodeTest: false
-                        isAsync: false
-                        asyncTimeout: 60000
-                        nodeName: ""
-                        generatedNodeName: "ATest"
-                        testGroups: [
-                            {
-                                name: "groupA"
-                                isSolo: false
-                                isIgnored: false
-                                isAsync: false
-                                filename: "${s`source/test.spec.bs`}"
-                                lineNumber: "4"
-                                setupFunctionName: ""
-                                tearDownFunctionName: ""
-                                beforeEachFunctionName: ""
-                                afterEachFunctionName: ""
-                                testCases: [
-                                    {
-                                        isSolo: false
-                                        noCatch: false
-                                        funcName: "rooiboos_test_case_${TestCaseMD5Sum}_0"
-                                        isIgnored: false
-                                        isAsync: false
-                                        asyncTimeout: 2000
-                                        slow: 1000
-                                        isParamTest: false
-                                        name: "is test1"
-                                        lineNumber: 7
-                                        paramLineNumber: 0
-                                        assertIndex: 0
-                                        rawParams: invalid
-                                        paramTestIndex: 0
-                                        expectedNumberOfParams: 0
-                                        isParamsValid: true
-                                    }
-                                    {
-                                        isSolo: false
-                                        noCatch: false
-                                        funcName: "rooiboos_test_case_${TestCaseMD5Sum}_1"
-                                        isIgnored: false
-                                        isAsync: false
-                                        asyncTimeout: 2000
-                                        slow: 75
-                                        isParamTest: false
-                                        name: "is test2"
-                                        lineNumber: 17
-                                        paramLineNumber: 0
-                                        assertIndex: 0
-                                        rawParams: invalid
-                                        paramTestIndex: 0
-                                        expectedNumberOfParams: 0
-                                        isParamsValid: true
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                end function
-                function __ATest_builder()
-                    instance = __rooibos_BaseTestSuite_builder()
-                    instance.super0_new = instance.new
-                    instance.new = __ATest_method_new
-                    instance.rooiboos_test_case_${TestCaseMD5Sum}_0 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0
-                    instance.rooiboos_test_case_${TestCaseMD5Sum}_1 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_1
-                    instance.super0_getTestSuiteData = instance.getTestSuiteData
-                    instance.getTestSuiteData = __ATest_method_getTestSuiteData
-                    return instance
-                end function
-                function ATest()
-                    instance = __ATest_builder()
-                    instance.new()
-                    return instance
-                end function
-            `);
 
+            const testFileContents = getContents('test.spec.brs');
+            const ast = getAstFromFileContents(testFileContents);
+            const functions = ast.statements.filter(isFunctionStatement);
+            const functionNames = functions.map(func => func.name.text);
+            expect(functionNames).to.include(`__ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0`);
+            expect(functionNames).to.include(`__ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_1`);
+            expect(functionNames).to.include(`__ATest_method_getTestSuiteData`);
+
+            const testSuiteDataFunc = functions.find(func => func.name.text === `__ATest_method_getTestSuiteData`);
+            const testSuiteDataFuncReturnStmt = testSuiteDataFunc.func.body.statements.filter(isReturnStatement)[0];
+
+            expect(isAALiteralExpression(testSuiteDataFuncReturnStmt.value)).to.be.true;
+
+            expectFunctionContents(testFileContents, `__ATest_method_getTestSuiteData`, `
+                return {
+                    name: "ATest"
+                    isSolo: false
+                    noCatch: false
+                    isIgnored: false
+                    isAsync: false
+                    pkgPath: "${s`source/test.spec.bs`}"
+                    filePath: "${s`${tmpPath}/rootDir/source/test.spec.bs`}"
+                    lineNumber: 3
+                    valid: true
+                    hasFailures: false
+                    hasSoloTests: false
+                    hasIgnoredTests: false
+                    hasSoloGroups: false
+                    setupFunctionName: ""
+                    tearDownFunctionName: ""
+                    beforeEachFunctionName: ""
+                    afterEachFunctionName: ""
+                    isNodeTest: false
+                    isAsync: false
+                    asyncTimeout: 60000
+                    nodeName: ""
+                    generatedNodeName: "ATest"
+                    testGroups: [
+                        {
+                            name: "groupA"
+                            isSolo: false
+                            isIgnored: false
+                            isAsync: false
+                            filename: "${s`source/test.spec.bs`}"
+                            lineNumber: "4"
+                            setupFunctionName: ""
+                            tearDownFunctionName: ""
+                            beforeEachFunctionName: ""
+                            afterEachFunctionName: ""
+                            testCases: [
+                                {
+                                    isSolo: false
+                                    noCatch: false
+                                    funcName: "rooiboos_test_case_${TestCaseMD5Sum}_0"
+                                    isIgnored: false
+                                    isAsync: false
+                                    asyncTimeout: 2000
+                                    slow: 1000
+                                    isParamTest: false
+                                    name: "is test1"
+                                    lineNumber: 7
+                                    paramLineNumber: 0
+                                    assertIndex: 0
+                                    rawParams: invalid
+                                    paramTestIndex: 0
+                                    expectedNumberOfParams: 0
+                                    isParamsValid: true
+                                }
+                                {
+                                    isSolo: false
+                                    noCatch: false
+                                    funcName: "rooiboos_test_case_${TestCaseMD5Sum}_1"
+                                    isIgnored: false
+                                    isAsync: false
+                                    asyncTimeout: 2000
+                                    slow: 75
+                                    isParamTest: false
+                                    name: "is test2"
+                                    lineNumber: 17
+                                    paramLineNumber: 0
+                                    assertIndex: 0
+                                    rawParams: invalid
+                                    paramTestIndex: 0
+                                    expectedNumberOfParams: 0
+                                    isParamsValid: true
+                                }
+                            ]
+                        }
+                    ]
+                }
+            `);
             //verify the AST was restored after transpile
             const cls = file.ast.statements[0] as ClassStatement;
             expect(cls.body.find((x) => {
@@ -901,13 +856,14 @@ describe('RooibosPlugin', () => {
             `);
             program.validate();
             await builder.transpile();
-            console.log(builder.getDiagnostics());
-            expect(builder.getDiagnostics()).to.have.length(1);
-            expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+            expectDiagnostics(builder, [
+                { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+            ]);
             expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
             expect(plugin.session.sessionInfo.suitesCount).to.equal(1);
             expect(plugin.session.sessionInfo.groupsCount).to.equal(1);
             expect(plugin.session.sessionInfo.testsCount).to.equal(1);
+            expect(plugin.session.sessionInfo.testSuites.get('ATest').testGroups.get('1groupA')).to.exist;
 
             expect(
                 getContents('rooibosMain.brs')
@@ -916,88 +872,66 @@ describe('RooibosPlugin', () => {
                     Rooibos_init("RooibosScene")
                 end function
             `);
-            expect(
-                getContents('test.spec.brs')
-            ).to.eql(undent`
-                sub __ATest_method_new()
-                    m.super0_new()
-                end sub
-                function __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0()
-                end function
-                function __ATest_method_getTestSuiteData()
-                    return {
-                        name: "ATest"
-                        isSolo: false
-                        noCatch: false
-                        isIgnored: false
-                        isAsync: false
-                        pkgPath: "${s`source/test.spec.bs`}"
-                        filePath: "${s`${tmpPath}/rootDir/source/test.spec.bs`}"
-                        lineNumber: 3
-                        valid: true
-                        hasFailures: false
-                        hasSoloTests: false
-                        hasIgnoredTests: false
-                        hasSoloGroups: false
-                        setupFunctionName: ""
-                        tearDownFunctionName: ""
-                        beforeEachFunctionName: ""
-                        afterEachFunctionName: ""
-                        isNodeTest: false
-                        isAsync: false
-                        asyncTimeout: 60000
-                        nodeName: ""
-                        generatedNodeName: "ATest"
-                        testGroups: [
-                            {
-                                name: "1groupA"
-                                isSolo: false
-                                isIgnored: false
-                                isAsync: false
-                                filename: "${s`source/test.spec.bs`}"
-                                lineNumber: "4"
-                                setupFunctionName: ""
-                                tearDownFunctionName: ""
-                                beforeEachFunctionName: ""
-                                afterEachFunctionName: ""
-                                testCases: [
-                                    {
-                                        isSolo: false
-                                        noCatch: false
-                                        funcName: "rooiboos_test_case_${TestCaseMD5Sum}_0"
-                                        isIgnored: false
-                                        isAsync: false
-                                        asyncTimeout: 2000
-                                        slow: 1000
-                                        isParamTest: false
-                                        name: "is test1"
-                                        lineNumber: 7
-                                        paramLineNumber: 0
-                                        assertIndex: 0
-                                        rawParams: invalid
-                                        paramTestIndex: 0
-                                        expectedNumberOfParams: 0
-                                        isParamsValid: true
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                end function
-                function __ATest_builder()
-                    instance = __rooibos_BaseTestSuite_builder()
-                    instance.super0_new = instance.new
-                    instance.new = __ATest_method_new
-                    instance.rooiboos_test_case_${TestCaseMD5Sum}_0 = __ATest_method_rooiboos_test_case_${TestCaseMD5Sum}_0
-                    instance.super0_getTestSuiteData = instance.getTestSuiteData
-                    instance.getTestSuiteData = __ATest_method_getTestSuiteData
-                    return instance
-                end function
-                function ATest()
-                    instance = __ATest_builder()
-                    instance.new()
-                    return instance
-                end function
+            const testFileContents = getContents('test.spec.brs');
+            expectFunctionContents(testFileContents, `__ATest_method_getTestSuiteData`, `
+                return {
+                    name: "ATest"
+                    isSolo: false
+                    noCatch: false
+                    isIgnored: false
+                    isAsync: false
+                    pkgPath: "${s`source/test.spec.bs`}"
+                    filePath: "${s`${tmpPath}/rootDir/source/test.spec.bs`}"
+                    lineNumber: 3
+                    valid: true
+                    hasFailures: false
+                    hasSoloTests: false
+                    hasIgnoredTests: false
+                    hasSoloGroups: false
+                    setupFunctionName: ""
+                    tearDownFunctionName: ""
+                    beforeEachFunctionName: ""
+                    afterEachFunctionName: ""
+                    isNodeTest: false
+                    isAsync: false
+                    asyncTimeout: 60000
+                    nodeName: ""
+                    generatedNodeName: "ATest"
+                    testGroups: [
+                        {
+                            name: "1groupA"
+                            isSolo: false
+                            isIgnored: false
+                            isAsync: false
+                            filename: "${s`source/test.spec.bs`}"
+                            lineNumber: "4"
+                            setupFunctionName: ""
+                            tearDownFunctionName: ""
+                            beforeEachFunctionName: ""
+                            afterEachFunctionName: ""
+                            testCases: [
+                                {
+                                    isSolo: false
+                                    noCatch: false
+                                    funcName: "rooiboos_test_case_${TestCaseMD5Sum}_0"
+                                    isIgnored: false
+                                    isAsync: false
+                                    asyncTimeout: 2000
+                                    slow: 1000
+                                    isParamTest: false
+                                    name: "is test1"
+                                    lineNumber: 7
+                                    paramLineNumber: 0
+                                    assertIndex: 0
+                                    rawParams: invalid
+                                    paramTestIndex: 0
+                                    expectedNumberOfParams: 0
+                                    isParamsValid: true
+                                }
+                            ]
+                        }
+                    ]
+                }
             `);
 
             //verify the AST was restored after transpile
@@ -1022,20 +956,23 @@ describe('RooibosPlugin', () => {
             `);
             program.validate();
             await builder.transpile();
-            console.log(builder.getDiagnostics());
-            expect(builder.getDiagnostics()).to.have.length(1);
-            expect(builder.getDiagnostics()[0].severity).to.equal(DiagnosticSeverity.Warning);
+            expectDiagnostics(builder, [
+                { code: 'RBS2213', severity: DiagnosticSeverity.Warning } // no main function
+            ]);
             expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
             expect(plugin.session.sessionInfo.suitesCount).to.equal(1);
             expect(plugin.session.sessionInfo.groupsCount).to.equal(1);
             expect(plugin.session.sessionInfo.testsCount).to.equal(1);
+            const testCase = plugin.session.sessionInfo.testSuites.get('ATest').testGroups.get('groupA').testCases[0];
+            expect(testCase.rawParams).to.eql([{ '"unknown_value"': 'color' }]);
 
-            expect(
-                getContents('rooibosMain.brs')
-            ).to.eql(undent`
-                function main()
-                    Rooibos_init("RooibosScene")
-                end function
+            const testFileContents = getContents('test.spec.brs');
+            expectFunctionContentsContains(testFileContents, `__ATest_method_getTestSuiteData`, `
+                rawParams: [
+                    {
+                       "unknown_value": "color"
+                    }
+                ]
             `);
         });
 
@@ -1116,10 +1053,7 @@ describe('RooibosPlugin', () => {
                 expect(program.getDiagnostics()).to.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 await builder.transpile();
-                const testContents = getTestFunctionContents();
-                expect(
-                    testContents
-                ).to.eql(undent`
+                expectTestFunctionContents(`
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "callFunc", m, "m.thing", [
                         "getFunction"
@@ -1211,10 +1145,7 @@ describe('RooibosPlugin', () => {
                 await builder.transpile();
                 expect(program.getDiagnostics().filter((d) => d.code !== 'RBS2213')).to.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
-                const testContents = getTestFunctionContents();
-                expect(
-                    testContents
-                ).to.eql(undent`
+                expectTestFunctionContents(`
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "getFunction", m, "m.thing", [])
                     if m.currentResult?.isFail = true then
@@ -1265,9 +1196,7 @@ describe('RooibosPlugin', () => {
                 await builder.transpile();
                 expect(program.getDiagnostics().filter((d) => d.code !== 'RBS2213')).to.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
-                expect(
-                    getTestSubContents()
-                ).to.eql(undent`
+                expectTestFunctionContents(`
                     m.currentAssertLineNumber = 7
                     m._expectCalled(m.thing, "getFunction", m, "m.thing", [])
                     if m.currentResult?.isFail = true then
@@ -1375,13 +1304,10 @@ describe('RooibosPlugin', () => {
                     end class
                 `);
                 program.validate();
-                expect(program.getDiagnostics()).to.be.empty;
-                // expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
+                expectZeroDiagnostics(program);
+                expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 await builder.transpile();
-                const testContents = getTestFunctionContents();
-                expect(
-                    testContents
-                ).to.eql(undent`
+                expectTestFunctionContents(`
                     b = {
                         someValue: "value"
                     }
@@ -1492,6 +1418,39 @@ describe('RooibosPlugin', () => {
                     end if
                 `);
             });
+
+            it('adds mocksByFunctionName lookup function', async () => {
+                program.setFile('source/test.spec.bs', `
+                    @suite
+                    class ATest
+                        @describe("groupA")
+                        @it("test1")
+                        function _()
+                            m.expectCalled(sayHello("arg1", "arg2"), "return")
+                        end function
+                    end class
+                `);
+                program.setFile('source/code.bs', `
+                    function sayHello(firstName = "" as string, lastName = "" as string)
+                        print firstName + " " + lastName
+                    end function
+                `);
+                program.validate();
+                expect(program.getDiagnostics()).to.be.empty;
+                expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
+                await builder.transpile();
+                let codeText = normalizeGeneratedMockFunctionNames(getContents('code.brs'));
+                let ast = getAstFromFileContents(codeText);
+                expect(ast.statements.find(s => isFunctionStatement(s) && s.name.text === 'RBS_SM_getMocksByFunctionName')).to.exist;
+
+                expectFunctionContents(codeText, 'RBS_SM_getMocksByFunctionName', `
+                    if m._rMocksByFunctionName = invalid
+                        m._rMocksByFunctionName = {}
+                    end if
+                    return m._rMocksByFunctionName
+                `);
+            });
+
             it('correctly transpiles global function calls', async () => {
 
                 program.setFile('source/test.spec.bs', `
@@ -1582,6 +1541,7 @@ describe('RooibosPlugin', () => {
                     end function
                 `);
             });
+
             it('correctly transpiles namespaced function calls', async () => {
                 plugin.config.isGlobalMethodMockingEnabled = true;
                 program.setFile('source/test.spec.bs', `
@@ -1649,30 +1609,21 @@ describe('RooibosPlugin', () => {
                 `);
 
                 let codeText = normalizeGeneratedMockFunctionNames(getContents('code.brs'));
-                expect(codeText).to.equal(undent(`
-                    function utils_sayHello(firstName = "", lastName = "")
-                        __stubs_globalAa = getGlobalAa()
-                        if RBS_SM_getMocksByFunctionName()["utils_sayhello"] <> invalid
-                            __stubOrMockResult = RBS_SM_getMocksByFunctionName()["utils_sayhello"].callback(firstName, lastName)
-                            return __stubOrMockResult
-                        else if type(__stubs_globalAa?.__globalStubs?.utils_sayhello).endsWith("Function")
-                            __stubFunction = __stubs_globalAa.__globalStubs.utils_sayhello
-                            __stubOrMockResult = __stubFunction(firstName, lastName)
-                            return __stubOrMockResult
-                        else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("utils_sayhello")
-                            value = __stubs_globalAa.__globalStubs.utils_sayhello
-                            return value
-                        end if
-                        print firstName + " " + lastName
-                    end function
-
-                    function RBS_SM_getMocksByFunctionName()
-                        if m._rMocksByFunctionName = invalid
-                            m._rMocksByFunctionName = {}
-                        end if
-                        return m._rMocksByFunctionName
-                    end function
-                `));
+                expectFunctionContents(codeText, 'utils_sayHello', `
+                    __stubs_globalAa = getGlobalAa()
+                    if RBS_SM_getMocksByFunctionName()["utils_sayhello"] <> invalid
+                        __stubOrMockResult = RBS_SM_getMocksByFunctionName()["utils_sayhello"].callback(firstName, lastName)
+                        return __stubOrMockResult
+                    else if type(__stubs_globalAa?.__globalStubs?.utils_sayhello).endsWith("Function")
+                        __stubFunction = __stubs_globalAa.__globalStubs.utils_sayhello
+                        __stubOrMockResult = __stubFunction(firstName, lastName)
+                        return __stubOrMockResult
+                    else if __stubs_globalAa?.__globalStubs <> invalid and __stubs_globalAa.__globalStubs.doesExist("utils_sayhello")
+                        value = __stubs_globalAa.__globalStubs.utils_sayhello
+                        return value
+                    end if
+                    print firstName + " " + lastName
+                `);
             });
         });
 
@@ -2345,9 +2296,7 @@ describe('RooibosPlugin', () => {
                 expect(program.getDiagnostics()).to.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 await builder.transpile();
-                expect(
-                    getTestFunctionContents()
-                ).to.eql(undent`
+                expectTestFunctionContents(`
                     m.currentAssertLineNumber = 7
                     m._expectNotCalled(m.thing, "getFunction", m, "m.thing")
                     if m.currentResult?.isFail = true then
@@ -2392,10 +2341,7 @@ describe('RooibosPlugin', () => {
                 expect(program.getDiagnostics()).to.be.empty;
                 expect(plugin.session.sessionInfo.testSuitesToRun).to.not.be.empty;
                 await builder.transpile();
-                const testContents = getTestFunctionContents();
-                expect(
-                    testContents
-                ).to.eql(undent`
+                expectTestFunctionContents(`
                     item = {
                         id: "item"
                     }
@@ -2596,7 +2542,7 @@ describe('RooibosPlugin', () => {
             await builder.transpile();
 
             expect(
-                getTestFunctionContents('ATest1')
+                getTestFunctionContents({ className: 'ATest1' })
             ).to.eql(undent`
                 item = {
                     id: "item"
@@ -2615,73 +2561,46 @@ describe('RooibosPlugin', () => {
                 end if
             `);
 
-            expect(
-                getContents('rooibos/RuntimeConfig.brs')
-            ).to.eql(undent`
-                'import "pkg:/source/rooibos/JUnitTestReporter.bs"
-                'import "pkg:/source/rooibos/ConsoleTestReporter.bs"
-                'import "pkg:/source/rooibos/MochaTestReporter.bs"
-                ' @ignore
-                function __rooibos_RuntimeConfig_method_new()
-                    m.testSuites = m.getTestSuiteClassMap()
-                end function
-                function __rooibos_RuntimeConfig_method_getVersionText()
-                    return "${version}"
-                end function
-                function __rooibos_RuntimeConfig_method_getRuntimeConfig()
-                    return {
-                        "reporters": [
-                            rooibos_ConsoleTestReporter
-                        ]
-                        "failFast": true
-                        "sendHomeOnFinish": true
-                        "logLevel": 0
-                        "showOnlyFailures": true
-                        "printTestTimes": true
-                        "lineWidth": 60
-                        "printLcov": false
-                        "port": "invalid"
-                        "catchCrashes": true
-                        "colorizeOutput": false
-                        "throwOnFailedAssertion": false
-                        "keepAppOpen": true
-                        "isRecordingCodeCoverage": false
-                    }
-                end function
-                function __rooibos_RuntimeConfig_method_getTestSuiteClassMap()
-                    return {
-                        "ATest1": ATest1
-                        "ATest2": ATest2
-                    }
-                end function
-                function __rooibos_RuntimeConfig_method_getTestSuiteClassWithName(name as string) as object
-                    return m.testSuites[name]
-                end function
-                function __rooibos_RuntimeConfig_method_getAllTestSuitesNames() as dynamic
-                    return m.testSuites.keys()
-                end function
-                function __rooibos_RuntimeConfig_method_getIgnoredTestInfo()
-                    return {
-                        "count": 0
-                        "items": []
-                    }
-                end function
-                function __rooibos_RuntimeConfig_builder()
-                    instance = {}
-                    instance.new = __rooibos_RuntimeConfig_method_new
-                    instance.getVersionText = __rooibos_RuntimeConfig_method_getVersionText
-                    instance.getRuntimeConfig = __rooibos_RuntimeConfig_method_getRuntimeConfig
-                    instance.getTestSuiteClassMap = __rooibos_RuntimeConfig_method_getTestSuiteClassMap
-                    instance.getTestSuiteClassWithName = __rooibos_RuntimeConfig_method_getTestSuiteClassWithName
-                    instance.getAllTestSuitesNames = __rooibos_RuntimeConfig_method_getAllTestSuitesNames
-                    instance.getIgnoredTestInfo = __rooibos_RuntimeConfig_method_getIgnoredTestInfo
-                    return instance
-                end function
-                function rooibos_RuntimeConfig()
-                    instance = __rooibos_RuntimeConfig_builder()
-                    instance.new()
-                    return instance
-                end function
+            const runtimeConfigContents = getContents('rooibos/RuntimeConfig.brs');
+
+            const runtimeConfigAst = getAstFromFileContents(runtimeConfigContents);
+
+            const commentedImports: CommentStatement[] = runtimeConfigAst.statements.filter(x => isCommentStatement(x) && x.text.startsWith(`'import`)) as CommentStatement[];
+            expect(commentedImports.length).to.greaterThan(0);
+            expect(commentedImports[0].text).to.include('pkg:/source/rooibos/JUnitTestReporter.bs');
+            expect(commentedImports[0].text).to.include('pkg:/source/rooibos/ConsoleTestReporter.bs');
+            expect(commentedImports[0].text).to.include('pkg:/source/rooibos/MochaTestReporter.bs');
+
+            expectFunctionContents(getContents('rooibos/RuntimeConfig.brs'), '__rooibos_RuntimeConfig_method_getVersionText', `
+                return "${version}"
+            `);
+
+            expectFunctionContents(getContents('rooibos/RuntimeConfig.brs'), '__rooibos_RuntimeConfig_method_getRuntimeConfig', `
+                return {
+                    "reporters": [
+                        rooibos_ConsoleTestReporter
+                    ]
+                    "failFast": true
+                    "sendHomeOnFinish": true
+                    "logLevel": 0
+                    "showOnlyFailures": true
+                    "printTestTimes": true
+                    "lineWidth": 60
+                    "printLcov": false
+                    "port": "invalid"
+                    "catchCrashes": true
+                    "colorizeOutput": false
+                    "throwOnFailedAssertion": false
+                    "keepAppOpen": true
+                    "isRecordingCodeCoverage": false
+                }
+            `);
+
+            expectFunctionContents(getContents('rooibos/RuntimeConfig.brs'), '__rooibos_RuntimeConfig_method_getTestSuiteClassMap', `
+                return {
+                    "ATest1": ATest1
+                    "ATest2": ATest2
+                }
             `);
 
             //the methods should be empty again after transpile has finished
@@ -2837,20 +2756,21 @@ describe('RooibosPlugin', () => {
 
         //load the source map
         await SourceMapConsumer.with(map, null, (consumer) => {
+            const mappedExpectedPositions = expectedLocations.map((x) => {
+                let originalPosition = consumer.originalPositionFor({
+                    //convert 0-based line to source-map 1-based line for the lookup
+                    line: x.dest[0] + 1,
+                    column: x.dest[1],
+                    bias: SourceMapConsumer.GREATEST_LOWER_BOUND
+                });
+                return Position.create(
+                    //convert 1-based source-map line to 0-based for the test
+                    originalPosition.line - 1,
+                    originalPosition.column
+                );
+            });
             expect(
-                expectedLocations.map((x) => {
-                    let originalPosition = consumer.originalPositionFor({
-                        //convert 0-based line to source-map 1-based line for the lookup
-                        line: x.dest[0] + 1,
-                        column: x.dest[1],
-                        bias: SourceMapConsumer.GREATEST_LOWER_BOUND
-                    });
-                    return Position.create(
-                        //convert 1-based source-map line to 0-based for the test
-                        originalPosition.line - 1,
-                        originalPosition.column
-                    );
-                })
+                mappedExpectedPositions
             ).to.eql(
                 expectedLocations.map(
                     x => Position.create(x.src[0], x.src[1])
@@ -2860,39 +2780,4 @@ describe('RooibosPlugin', () => {
     }
 });
 
-function getContents(filename: string) {
-    return undent(
-        fsExtra.readFileSync(s`${_stagingFolderPath}/source/${filename}`).toString()
-    );
-}
 
-function getTestFunctionContents(className = 'ATest', index = 0) {
-    const contents = getContents('test.spec.brs');
-    const funcNameRegex = new RegExp(`__${className}_method_rooiboos_test_case_.*_${index}`);
-
-    return getFunctionContents(contents, funcNameRegex);
-}
-
-function getFunctionContents(rawCode: string, functionNameRegex: RegExp) {
-    const { ast } = Parser.parse(rawCode);
-    const funcStmt = ast.statements.find((stmt) => {
-        return stmt instanceof FunctionStatement && functionNameRegex.test(stmt.name.text);
-    }) as FunctionStatement | undefined;
-
-    const bodyRange = funcStmt?.func.body.range;
-    if (bodyRange) {
-        const lines = rawCode.split(/\r?\n/);
-        const extractedLines = lines.slice(bodyRange.start.line, bodyRange.end.line + 1);
-        return undent(extractedLines.join('\n'));
-    }
-
-    return '';
-}
-
-function getTestSubContents() {
-    return getTestFunctionContents();
-}
-
-function normalizeGeneratedMockFunctionNames(text: string) {
-    return text.replace(/RBS_SM_[0-9]+_getMocksByFunctionName/g, 'RBS_SM_getMocksByFunctionName');
-}

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -1,7 +1,15 @@
 import * as chai from 'chai';
 const expect = chai.expect;
 import type { TestCase } from './lib/rooibos/TestCase';
+import { FunctionStatement, isClassStatement, ParseMode, Parser, standardizePath as s } from 'brighterscript';
+import type { Body, BscFile, BsDiagnostic, ClassStatement, CodeDescription, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, ParseOptions } from 'brighterscript';
+import type { Range } from 'vscode-languageserver';
+import * as fsExtra from 'fs-extra';
+import undent from 'undent';
 
+let tmpPath = s`${process.cwd()}/.tmp`;
+let _rootDir = s`${tmpPath}/rootDir`;
+let _stagingFolderPath = s`${tmpPath}/staging`;
 
 export const TestCaseMD5Sum = `0d635a9477c4624180ef87bef352afd3`;
 
@@ -10,3 +18,139 @@ const TestCaseFunctionNameRegex = new RegExp(`^rooiboos_test_case_${TestCaseMD5S
 export function expectTestCaseFunctionName(testCase: TestCase, index: number) {
     expect(testCase.funcName).to.match(new RegExp(TestCaseFunctionNameRegex.source + index + '$'));
 }
+
+
+type DiagnosticCollection = { getDiagnostics(): Array<BsDiagnostic> } | { diagnostics: BsDiagnostic[] } | BsDiagnostic[];
+export interface PartialDiagnostic {
+    range?: Range;
+    severity?: DiagnosticSeverity;
+    code?: number | string;
+    codeDescription?: Partial<CodeDescription>;
+    source?: string;
+    message?: string;
+    tags?: Partial<DiagnosticTag>[];
+    relatedInformation?: Partial<DiagnosticRelatedInformation>[];
+    data?: unknown;
+    file?: Partial<BscFile>;
+}
+
+export function expectDiagnostics(diagnostics: DiagnosticCollection, expected: Array<PartialDiagnostic>) {
+    const actualDiagnostics = getActualDiagnostics(diagnostics);
+
+    expect(actualDiagnostics).to.have.length(expected.length);
+    expected.forEach((expectedDiagnostic, index) => {
+        const actualDiagnostic = actualDiagnostics[index];
+        if (expectedDiagnostic.file) {
+            expect(actualDiagnostic.file).to.exist;
+            expect(actualDiagnostic.file.pkgPath).to.equal(expectedDiagnostic.file.pkgPath);
+        }
+        if (expectedDiagnostic.code) {
+            expect(actualDiagnostic.code).to.equal(expectedDiagnostic.code);
+        }
+        if (expectedDiagnostic.range) {
+            expect(actualDiagnostic.range).to.exist;
+            expect(actualDiagnostic.range.start.line).to.equal(expectedDiagnostic.range.start.line);
+            expect(actualDiagnostic.range.start.character).to.equal(expectedDiagnostic.range.start.character);
+            expect(actualDiagnostic.range.end.line).to.equal(expectedDiagnostic.range.end.line);
+            expect(actualDiagnostic.range.end.character).to.equal(expectedDiagnostic.range.end.character);
+        }
+        if (expectedDiagnostic.message) {
+            expect(actualDiagnostic.message).to.equal(expectedDiagnostic.message);
+        }
+    });
+}
+
+function getActualDiagnostics(diagnostics: DiagnosticCollection): Array<BsDiagnostic> {
+    if ('getDiagnostics' in diagnostics) {
+        return diagnostics.getDiagnostics();
+    } else if ('diagnostics' in diagnostics) {
+        return diagnostics.diagnostics;
+    } else {
+        return diagnostics;
+    }
+}
+
+export function expectZeroDiagnostics(diagnostics: DiagnosticCollection) {
+    const actualDiagnostics = getActualDiagnostics(diagnostics);
+    expect(actualDiagnostics).to.be.empty;
+}
+
+export function getContents(filename: string) {
+    return undent(
+        fsExtra.readFileSync(s`${_stagingFolderPath}/source/${filename}`).toString()
+    );
+}
+
+export function getAstFromFileContents(contents: string, options?: ParseOptions) {
+    const parser = new Parser();
+    const { ast } = parser.parse(contents, options);
+    return ast;
+}
+
+
+export function expectFunctionContents(fileContents: string, functionName: string, expectedContents: string) {
+    const contents = getFunctionContents(fileContents, functionName);
+    if (contents) {
+        expect(undent(contents)).to.equal(undent(expectedContents));
+    }
+}
+
+export function expectFunctionContentsContains(fileContents: string, functionName: string, expectedContents: string) {
+    let contents = getFunctionContents(fileContents, functionName);
+    expectedContents = expectedContents.replace(/ +/g, ' ');
+    if (contents) {
+        contents = contents.replace(/ +/g, ' ');
+        expect(contents).to.contain(expectedContents);
+    }
+}
+
+export interface TestFunctionContentsOptions {
+    className?: string;
+    index?: number;
+    testFile?: string;
+}
+
+function normalizeTestFunctionContentsOptions(options: TestFunctionContentsOptions = {}) {
+    return {
+        className: options.className ?? 'ATest',
+        index: options.index ?? 0,
+        testFile: options.testFile ?? 'test.spec.brs'
+    };
+}
+
+export function getTestFunctionContents(options?: TestFunctionContentsOptions) {
+    const { className, index, testFile } = normalizeTestFunctionContentsOptions(options);
+    const contents = getContents(testFile);
+    const funcNameRegex = new RegExp(`__${className}_method_rooiboos_test_case_.*_${index}`);
+
+    return getFunctionContents(contents, funcNameRegex);
+}
+
+export function expectTestFunctionContents(expectedContents: string, options?: TestFunctionContentsOptions) {
+    const contents = getTestFunctionContents(options);
+    if (contents) {
+        expect(undent(contents)).to.equal(undent(expectedContents));
+    }
+}
+
+export function getFunctionContents(rawCode: string, functionName: RegExp | string) {
+    const ast = getAstFromFileContents(rawCode);
+    const funcStmt = ast.statements.find((stmt) => {
+        return stmt instanceof FunctionStatement && (typeof functionName === 'string' ? stmt.name.text === functionName : functionName.test(stmt.name.text));
+    }) as FunctionStatement | undefined;
+
+    const bodyRange = funcStmt?.func.body.range;
+    if (bodyRange) {
+        const lines = rawCode.split(/\r?\n/);
+        const extractedLines = lines.slice(bodyRange.start.line, bodyRange.end.line + 1);
+        return undent(extractedLines.join('\n'));
+    }
+
+    return '';
+}
+
+
+export function normalizeGeneratedMockFunctionNames(text: string) {
+    return text.replace(/RBS_SM_[0-9]+_getMocksByFunctionName/g, 'RBS_SM_getMocksByFunctionName');
+}
+

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -69,8 +69,18 @@ function getActualDiagnostics(diagnostics: DiagnosticCollection): Array<BsDiagno
     }
 }
 
+function getSortedActualDiagnostics(diagnostics: DiagnosticCollection): Array<BsDiagnostic> {
+    const diags = getActualDiagnostics(diagnostics);
+    return diags.sort((a, b) => {
+        return a.code.toString().localeCompare(b.code.toString()) ||
+            a.message.localeCompare(b.message) ||
+            a.range.start.line - b.range.start.line ||
+            a.range.start.character - b.range.start.character;
+    });
+}
+
 export function expectZeroDiagnostics(diagnostics: DiagnosticCollection) {
-    const actualDiagnostics = getActualDiagnostics(diagnostics);
+    const actualDiagnostics = getSortedActualDiagnostics(diagnostics);
     expect(actualDiagnostics).to.be.empty;
 }
 
@@ -103,6 +113,7 @@ function normalizeFunctionContentsForContains(value: string) {
 
 export function expectFunctionContentsContains(fileContents: string, functionName: string, expectedContents: string) {
     const contents = getFunctionContents(fileContents, functionName);
+    expect(contents, `Function not found: '${functionName}'`).to.not.equal('');
     if (contents) {
         expect(normalizeFunctionContentsForContains(contents)).to.contain(normalizeFunctionContentsForContains(expectedContents));
     }
@@ -132,8 +143,11 @@ export function getTestFunctionContents(options?: TestFunctionContentsOptions) {
 
 export function expectTestFunctionContents(expectedContents: string, options?: TestFunctionContentsOptions) {
     const contents = getTestFunctionContents(options);
+    expect(contents, 'Test function not found').to.not.equal('');
     if (contents) {
         expect(undent(contents)).to.equal(undent(expectedContents));
+    } else {
+
     }
 }
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -75,8 +75,11 @@ export function expectZeroDiagnostics(diagnostics: DiagnosticCollection) {
 }
 
 export function getContents(filename: string) {
+    if (!filename.includes('/')) {
+        filename = `source/${filename}`;
+    }
     return undent(
-        fsExtra.readFileSync(s`${_stagingFolderPath}/source/${filename}`).toString()
+        fsExtra.readFileSync(s`${_stagingFolderPath}/${filename}`).toString()
     );
 }
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -1,15 +1,14 @@
 import * as chai from 'chai';
 const expect = chai.expect;
 import type { TestCase } from './lib/rooibos/TestCase';
-import { FunctionStatement, isClassStatement, ParseMode, Parser, standardizePath as s } from 'brighterscript';
-import type { Body, BscFile, BsDiagnostic, ClassStatement, CodeDescription, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, ParseOptions } from 'brighterscript';
+import { FunctionStatement, Parser, standardizePath as s } from 'brighterscript';
+import type { BscFile, BsDiagnostic, CodeDescription, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, ParseOptions } from 'brighterscript';
 import type { Range } from 'vscode-languageserver';
 import * as fsExtra from 'fs-extra';
 import undent from 'undent';
 
-let tmpPath = s`${process.cwd()}/.tmp`;
-let _rootDir = s`${tmpPath}/rootDir`;
-let _stagingFolderPath = s`${tmpPath}/staging`;
+const tmpPath = s`${process.cwd()}/.tmp`;
+const _stagingFolderPath = s`${tmpPath}/staging`;
 
 export const TestCaseMD5Sum = `0d635a9477c4624180ef87bef352afd3`;
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -1,0 +1,12 @@
+import * as chai from 'chai';
+const expect = chai.expect;
+import type { TestCase } from './lib/rooibos/TestCase';
+
+
+export const TestCaseMD5Sum = `0d635a9477c4624180ef87bef352afd3`;
+
+const TestCaseFunctionNameRegex = new RegExp(`^rooiboos_test_case_${TestCaseMD5Sum}_`);
+
+export function expectTestCaseFunctionName(testCase: TestCase, index: number) {
+    expect(testCase.funcName).to.match(new RegExp(TestCaseFunctionNameRegex.source + index + '$'));
+}

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -97,12 +97,14 @@ export function expectFunctionContents(fileContents: string, functionName: strin
     }
 }
 
+function normalizeFunctionContentsForContains(value: string) {
+    return undent(value).replace(/\s+/g, ' ').trim();
+}
+
 export function expectFunctionContentsContains(fileContents: string, functionName: string, expectedContents: string) {
-    let contents = getFunctionContents(fileContents, functionName);
-    expectedContents = expectedContents.replace(/ +/g, ' ');
+    const contents = getFunctionContents(fileContents, functionName);
     if (contents) {
-        contents = contents.replace(/ +/g, ' ');
-        expect(contents).to.contain(expectedContents);
+        expect(normalizeFunctionContentsForContains(contents)).to.contain(normalizeFunctionContentsForContains(expectedContents));
     }
 }
 

--- a/src/testHelpers.spec.ts
+++ b/src/testHelpers.spec.ts
@@ -156,3 +156,9 @@ export function normalizeGeneratedMockFunctionNames(text: string) {
     return text.replace(/RBS_SM_[0-9]+_getMocksByFunctionName/g, 'RBS_SM_getMocksByFunctionName');
 }
 
+export function getFunctionAstNode(rawCode: string, functionName: RegExp | string) {
+    const ast = getAstFromFileContents(rawCode);
+    return ast.statements.find((stmt) => {
+        return stmt instanceof FunctionStatement && (typeof functionName === 'string' ? stmt.name.text === functionName : functionName.test(stmt.name.text));
+    }) as FunctionStatement | undefined;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,11 @@
     "noUnusedLocals": true,
     "typeRoots": [
       "./node_modules/@types"
+    ],
+    "types": [
+      "node",
+      "mocha",
+      "chai"
     ]
   },
   "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This PR aims to make the tests less brittle, so that external changes do not cause tests to fail.

For example:
- how Brighterscript transpiles code
- different files included, causing indexed functions to have different signatures

To accomplish this:
- Common functions (like "getContents") moved to common files
- Look at generated AST instead of string comparisons of transpiled code
- Helper `expect` functions to do away with some boilerplate
- Look at specific function contents instead of the whole file.