### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -493,24 +493,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -553,6 +535,20 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
@@ -3241,12 +3237,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
         "node_modules/eslint/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3321,18 +3311,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/eslint/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -4803,17 +4781,34 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/js-yaml/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
         },
         "node_modules/js2xmlparser": {
             "version": "4.0.2",
@@ -5387,12 +5382,6 @@
                 "node": ">= 14.0.0"
             }
         },
-        "node_modules/mocha/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
         "node_modules/mocha/node_modules/brace-expansion": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
@@ -5458,18 +5447,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/mocha/node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/mocha/node_modules/locate-path": {
@@ -8548,7 +8525,7 @@
                 "globals": "^13.15.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.3.1",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
@@ -8563,21 +8540,6 @@
                         "fast-json-stable-stringify": "^2.0.0",
                         "json-schema-traverse": "^0.4.1",
                         "uri-js": "^4.2.2"
-                    }
-                },
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-                    "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
                     }
                 },
                 "json-schema-traverse": {
@@ -8614,10 +8576,20 @@
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
                 "get-package-type": "^0.1.0",
-                "js-yaml": "^3.13.1",
+                "js-yaml": "^3.15.1",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
+                "js-yaml": {
+                    "version": "3.15.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+                    "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
                 "resolve-from": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10426,7 +10398,7 @@
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.3.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
@@ -10460,12 +10432,6 @@
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
-                },
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
                 },
                 "chalk": {
                     "version": "4.1.2",
@@ -10518,15 +10484,6 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-                    "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
                 },
                 "json-schema-traverse": {
                     "version": "0.4.1",
@@ -11751,13 +11708,20 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                }
             }
         },
         "js2xmlparser": {
@@ -12172,7 +12136,7 @@
                 "find-up": "^5.0.0",
                 "glob": "^8.1.0",
                 "he": "^1.2.0",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.3.1",
                 "log-symbols": "^4.1.0",
                 "minimatch": "^5.1.6",
                 "ms": "^2.1.3",
@@ -12185,12 +12149,6 @@
                 "yargs-unparser": "^2.0.0"
             },
             "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
                 "brace-expansion": {
                     "version": "2.1.4",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
@@ -12234,15 +12192,6 @@
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-                    "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
                 },
                 "locate-path": {
                     "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
         "typescript": "^4.7.2"
     },
     "overrides": {
-        "serialize-javascript": "^7.0.5"
+        "serialize-javascript": "^7.0.5",
+        "js-yaml@^3": "^3.15.1",
+        "js-yaml@^4": "^4.3.1"
     },
     "main": "dist/plugin.js",
     "bin": {


### PR DESCRIPTION
Clears the `js-yaml` high-severity advisories that were failing `npm run audit`. The gate now passes ("Passed npm security audit").

`npm audit --omit=dev`: **5 moderate** across 255 prod deps — unchanged by this PR, see the note below. Full audit went 9 → 8, zero high remaining.

## Ships to consumers

Nothing. `js-yaml` is dev-only here, and the `overrides` block is not inherited by consumers.

## Lockfile only (dev deps)

Both majors are in the tree, so each is scoped to its own line rather than forcing a single version.

| Package | Via | Was | Now |
|---|---|---|---|
| `js-yaml` | `eslint`, `mocha` | 4.1.1 | `^4.3.1` |
| `js-yaml` | `nyc`→`@istanbuljs/load-nyc-config` | 3.14.2 | `^3.15.1` |

## Notes for the reviewer

- **The prod `qs`/`uuid` moderates are deliberately left alone.** They reach consumers via `roku-debug`/`roku-deploy`→`postman-request`, and I checked: `roku-deploy@3.17.7` still pulls `postman-request`, and the newest `postman-request` (`.49`) moves `qs` to `~6.14.1` — still inside the vulnerable `6.11.1 - 6.15.1` range — and keeps `uuid@^8.3.2`. So the only fix is a breaking major bump of a direct prod dep. Recommend leaving until `postman-request` ships a clean release upstream.
- The `uuid` `audit-ci.jsonc` allowlist entry is kept as-is.

## Verification

`npm run preversion` passes — build, lint, and 130 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
