### PR TITLE
chore: Add a device-test config for exercising the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "test:nocover": "mocha",
         "audit": "npm audit || audit-ci --config ./audit-ci.jsonc",
         "cli": "ts-node src/cli.ts",
+        "cli:device": "ts-node src/cli.ts --project test-project/bsconfig.device.json",
         "package": "npm run build && npm pack"
     },
     "dependencies": {

--- a/test-project/bsconfig.device.json
+++ b/test-project/bsconfig.device.json
@@ -1,0 +1,20 @@
+{
+    "//": "Config for running the rooibos CLI against a real Roku device. See 'npm run cli:device'.",
+    "extends": "./bsconfig.json",
+    "createPackage": true,
+    "outFile": "out/rooibos-device-test.zip",
+    "rooibos": {
+        "showOnlyFailures": true,
+        "catchCrashes": true,
+        "colorizeOutput": true,
+        "lineWidth": 70,
+        "failFast": false,
+        "sendHomeOnFinish": false,
+        "keepAppOpen": false,
+        "isGlobalMethodMockingEnabled": true,
+        "isRecordingCodeCoverage": false,
+        "reporters": [
+            "mocha"
+        ]
+    }
+}


### PR DESCRIPTION
The `rooibos` CLI has no automated coverage — the unit tests only exercise the brighterscript plugin — so verifying it means running against a real Roku. The existing `test-project/bsconfig.json` can't drive it: `createPackage` is `false` and there's no `outFile`, so there's no zip to sideload.

Adds `test-project/bsconfig.device.json` (extends the existing config, sets `createPackage`/`outFile`, and `keepAppOpen: false` so the app emits `[Rooibos Shutdown]` and the CLI's exit path — home keypress, exit-code propagation — actually runs) plus a `cli:device` script:

```
npm run cli:device -- --host <ip> --password <pw>
```

Verified against a Roku Streaming Stick+ (16.0.4): deploys, runs the suite, and exits `1` from `[Rooibos Result]: FAIL`. That FAIL is expected — the fixture intentionally contains failing suites (`Rooibos failed assertion tests`, `SuiteTimeouts`, etc.), so the tally is ~477 passed / 235 failing / 4 crashed / 8 skipped.

Manual/local only; it needs hardware, so it can't run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)