### PR TITLE
chore: Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -538,9 +538,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5039,9 +5039,9 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {
@@ -9186,7 +9186,7 @@
                 "globals": "^13.15.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
@@ -9237,14 +9237,14 @@
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
                 "get-package-type": "^0.1.0",
-                "js-yaml": "^3.15.1",
+                "js-yaml": "^3.15.2",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
                 "js-yaml": {
-                    "version": "3.15.1",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-                    "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+                    "version": "3.15.2",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+                    "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
                     "dev": true,
                     "requires": {
                         "argparse": "^1.0.7",
@@ -11226,7 +11226,7 @@
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
@@ -12544,9 +12544,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
@@ -12973,7 +12973,7 @@
                 "find-up": "^5.0.0",
                 "glob": "^8.1.0",
                 "he": "^1.2.0",
-                "js-yaml": "^4.3.1",
+                "js-yaml": "^4.3.2",
                 "log-symbols": "^4.1.0",
                 "minimatch": "^5.1.6",
                 "ms": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     },
     "overrides": {
         "serialize-javascript": "^7.0.5",
-        "js-yaml@^3": "^3.15.1",
-        "js-yaml@^4": "^4.3.1",
+        "js-yaml@^3": "^3.15.2",
+        "js-yaml@^4": "^4.3.2",
         "browserslist": "^4.28.8"
     },
     "main": "dist/plugin.js",


### PR DESCRIPTION
Clears GHSA-2883-xcg3-v3hh (js-yaml, high), which is the only advisory failing the audit gate.

`npm audit --omit=dev`: 4 moderate, 0 high — unchanged by this PR (all prod advisories are below the gate's `high` floor).

## Ships to consumers
Nothing. Every change here is dev-scoped.

## Lockfile only (dev deps)
| Override | Before | After | Reached via |
|---|---|---|---|
| `js-yaml@^3` | `^3.15.1` | `^3.15.2` | `nyc > @istanbuljs/load-nyc-config` |
| `js-yaml@^4` | `^4.3.1` | `^4.3.2` | `eslint`, `mocha`, `nyc` |

## Notes for the reviewer
- The previous pins landed exactly inside the new advisory's range (`3.0.0 - 3.15.1 || 4.0.0 - 4.3.1`), so the gate went red without anything in this repo changing. Both bumps are patch-level.
- Remaining moderate advisories (`uuid`, `qs`, `@babel/core`) are below the `high` floor and don't fail the gate; `uuid` stays allowlisted on the existing reachability argument.

## Verification
`npm run preversion` (build + lint + test) passes, and `npm run audit` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)