### PR TITLE
chore: Fix mocha ts-node shim on Node 22+

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,15 @@
+const nodeVersion = +process.versions.node.split('.')[0];
+const config = {
+    spec: 'src/**/*.spec.ts',
+    require: [
+        'source-map-support/register',
+        'ts-node/register'
+    ],
+    fullTrace: true,
+    timeout: 2000,
+    watchExtensions: ['ts']
+};
+if (nodeVersion >= 22) {
+    config['node-option'] = ['no-experimental-strip-types'];
+}
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -113,17 +113,6 @@
         "functions": 5,
         "branches": 5
     },
-    "mocha": {
-        "spec": "src/**/*.spec.ts",
-        "fullTrace": true,
-        "require": [
-            "source-map-support/register",
-            "ts-node/register"
-        ],
-        "watchExtensions": [
-            "ts"
-        ]
-    },
     "ropm": {
         "rootDir": "./framework/src"
     }


### PR DESCRIPTION
`npm run test` fails on Node 22+ with `ReferenceError: __dirname is not defined in ES module scope`. Node 22 enables experimental TypeScript type-stripping, which claims `.ts` files and loads them as ES modules before `ts-node/register` can handle them, dropping the CommonJS `__dirname` binding.

The mocha config lived inline in `package.json`, so it couldn't apply a flag conditionally. Moved it to `.mocharc.cjs`, which passes `--no-experimental-strip-types` when the major Node version is >= 22 — same approach as brighterscript.

- Add `.mocharc.cjs` with the version-conditional `node-option`
- Remove the now-redundant `"mocha"` block from `package.json` (it would otherwise shadow the rc file)

The explicit `timeout: 2000` restates mocha's existing default, so timeouts are unchanged.

Verified with `npm run test` (136 passing) and `npm run lint`. Note: only Node 18 is installed on my machine, so I confirmed the rc file drives the run and that `--node-option` takes the flag in that form, but the Node 22+ path itself is unverified locally — CI should cover it if it runs a 22+ matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
